### PR TITLE
v0.2.99

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,25 +161,25 @@ Here are benchmarks comparing Scrapling to popular Python libraries in two tests
 
 | # |      Library      | Time (ms) | vs Scrapling | 
 |---|:-----------------:|:---------:|:------------:|
-| 1 |     Scrapling     |   5.44    |     1.0x     |
-| 2 |   Parsel/Scrapy   |   5.53    |    1.017x    |
-| 3 |     Raw Lxml      |   6.76    |    1.243x    |
-| 4 |      PyQuery      |   21.96   |    4.037x    |
-| 5 |    Selectolax     |   67.12   |   12.338x    |
-| 6 |   BS4 with Lxml   |  1307.03  |   240.263x   |
-| 7 |  MechanicalSoup   |  1322.64  |   243.132x   |
-| 8 | BS4 with html5lib |  3373.75  |   620.175x   |
+| 1 |     Scrapling     |   5.55    |     1.0x     |
+| 2 |   Parsel/Scrapy   |   5.67    |    1.022x    |
+| 3 |     Raw Lxml      |   6.69    |    1.205x    |
+| 4 |      PyQuery      |   20.84   |    3.755x    |
+| 5 |    Selectolax     |   84.41   |   15.209x    |
+| 6 |   BS4 with Lxml   |  1313.45  |   236.658x   |
+| 7 |  MechanicalSoup   |  1313.66  |   236.695x   |
+| 8 | BS4 with html5lib |  3383.27  |   609.598x   |
 
-As you see, Scrapling is on par with Scrapy and slightly faster than Lxml which both libraries are built on top of. These are the closest results to Scrapling. PyQuery is also built on top of Lxml but still, Scrapling is 4 times faster.
+As you see, Scrapling is on par with Scrapy and slightly faster than Lxml which both libraries are built on top of. These are the closest results to Scrapling. PyQuery is also built on top of Lxml but still, Scrapling is ~4 times faster.
 
 ### Extraction By Text Speed Test
 
 |   Library   | Time (ms) | vs Scrapling |
 |:-----------:|:---------:|:------------:|
-|  Scrapling  |   2.51    |     1.0x     |
-| AutoScraper |   11.41   |    4.546x    |
+|  Scrapling  |   2.35    |     1.0x     |
+| AutoScraper |   11.44   |    4.868x    |
 
-Scrapling can find elements with more methods and it returns full element `Adaptor` objects not only the text like AutoScraper. So, to make this test fair, both libraries will extract an element with text, find similar elements, and then extract the text content for all of them. As you see, Scrapling is still 4.5 times faster at the same task.
+Scrapling can find elements with more methods and it returns full element `Adaptor` objects not only the text like AutoScraper. So, to make this test fair, both libraries will extract an element with text, find similar elements, and then extract the text content for all of them. As you see, Scrapling is still 4.8 times faster at the same task.
 
 > All benchmarks' results are an average of 100 runs. See our [benchmarks.py](https://github.com/D4Vinci/Scrapling/blob/main/benchmarks.py) for methodology and to run your comparisons.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,36 @@
 # 🕷️ Scrapling: Undetectable, Lightning-Fast, and Easy Web Scraping with Python
-[![Tests](https://github.com/D4Vinci/Scrapling/actions/workflows/tests.yml/badge.svg)](https://github.com/D4Vinci/Scrapling/actions/workflows/tests.yml) [![PyPI version](https://badge.fury.io/py/Scrapling.svg)](https://badge.fury.io/py/Scrapling) [![Supported Python versions](https://img.shields.io/pypi/pyversions/scrapling.svg)](https://pypi.org/project/scrapling/) [![PyPI Downloads](https://static.pepy.tech/badge/scrapling)](https://pepy.tech/project/scrapling)
+<p align="center">
+    <a href="https://github.com/D4Vinci/Scrapling/actions/workflows/tests.yml" alt="Tests">
+        <img alt="Tests" src="https://github.com/D4Vinci/Scrapling/actions/workflows/tests.yml/badge.svg"></a>
+    <a href="https://badge.fury.io/py/Scrapling" alt="PyPI version">
+        <img alt="PyPI version" src="https://badge.fury.io/py/Scrapling.svg"></a>
+    <a href="https://pepy.tech/project/scrapling" alt="PyPI Downloads">
+        <img alt="PyPI Downloads" src="https://static.pepy.tech/badge/scrapling"></a>
+    <br/>
+    <a href="https://pypi.org/project/scrapling/" alt="Supported Python versions">
+        <img alt="Supported Python versions" src="https://img.shields.io/pypi/pyversions/scrapling.svg"></a>
+</p>
+<p align="center">
+    <a href="https://scrapling.readthedocs.io/en/latest/#installation">
+        Installation
+    </a>
+    ·
+    <a href="https://scrapling.readthedocs.io/en/latest/overview/">
+        Overview
+    </a>
+    ·
+    <a href="https://scrapling.readthedocs.io/en/latest/parsing/selection/">
+        Selection methods
+    </a>
+    ·
+    <a href="https://scrapling.readthedocs.io/en/latest/fetching/choosing/">
+        Choosing a fetcher
+    </a>
+    ·
+    <a href="https://scrapling.readthedocs.io/en/latest/tutorials/migrating_from_beautifulsoup/">
+        Migrating from Beautifulsoup
+    </a>
+</p>
 
 Dealing with failing web scrapers due to anti-bot protections or website changes? Meet Scrapling.
 
@@ -21,7 +52,7 @@ Scrapling is a high-performance, intelligent web scraping library for Python tha
 
 [Scrapeless Deep SerpApi](https://www.scrapeless.com/en/product/deep-serp-api?utm_source=website&utm_medium=ads&utm_campaign=scraping&utm_term=d4vinci) From $0.10 per 1,000 queries with a 1-2 second response time! 
 
-Deep SerpApi is a dedicated search engine designed for large language models (LLMs) and AI agents, aiming to provide real-time, accurate and unbiased information to help AI applications retrieve and process data efficiently.
+Deep SerpApi is a dedicated search engine designed for large language models (LLMs) and AI agents. It aims to provide real-time, accurate, and unbiased information to help AI applications retrieve and process data efficiently.
 - covering 20+ Google SERP scenarios and mainstream search engines.
 - support real-time data updates to ensure real-time and accurate information.
 - It can integrate information from all available online channels and search engines.
@@ -50,62 +81,18 @@ Deep SerpApi is a dedicated search engine designed for large language models (LL
 [![Evomi Banner](https://my.evomi.com/images/brand/cta.png)](https://evomi.com?utm_source=github&utm_medium=banner&utm_campaign=d4vinci-scrapling)
 ---
 
-## Table of content
-* [Key Features](#key-features)
-  * [Fetch websites as you prefer with async support](#fetch-websites-as-you-prefer-with-async-support)
-  * [Adaptive Scraping](#adaptive-scraping)
-  * [High Performance](#high-performance)
-  * [Developer Friendly](#developer-friendly)
-* [Getting Started](#getting-started)
-* [Parsing Performance](#parsing-performance)
-  * [Text Extraction Speed Test (5000 nested elements).](#text-extraction-speed-test-5000-nested-elements)
-  * [Extraction By Text Speed Test](#extraction-by-text-speed-test)
-* [Installation](#installation)
-* [Fetching Websites](#fetching-websites)
-  * [Features](#features)
-    * [Set parser config per request](#set-parser-config-per-request)
-  * [Fetcher](#fetcher)
-  * [StealthyFetcher](#stealthyfetcher)
-    * [The complete list of arguments](#the-complete-list-of-arguments)
-  * [PlayWrightFetcher](#playwrightfetcher)
-    * [The complete list of arguments](#the-complete-list-of-arguments-1)
-* [Advanced Parsing Features](#advanced-parsing-features)
-  * [Smart Navigation](#smart-navigation)
-  * [Content-based Selection & Finding Similar Elements](#content-based-selection--finding-similar-elements)
-  * [Handling Structural Changes](#handling-structural-changes)
-    * [Real-World Scenario](#real-world-scenario)
-  * [Find elements by filters](#find-elements-by-filters)
-  * [Is That All?](#is-that-all)
-* [More Advanced Usage](#more-advanced-usage)
-* [⚡ Enlightening Questions and FAQs](#-enlightening-questions-and-faqs)
-  * [How does auto-matching work?](#how-does-auto-matching-work)
-  * [How does the auto-matching work if I didn't pass a URL while initializing the Adaptor object?](#how-does-the-auto-matching-work-if-i-didnt-pass-a-url-while-initializing-the-adaptor-object)
-  * [If all things about an element can change or get removed, what are the unique properties to be saved?](#if-all-things-about-an-element-can-change-or-get-removed-what-are-the-unique-properties-to-be-saved)
-  * [I have enabled the `auto_save`/`auto_match` parameter while selecting and it got completely ignored with a warning message](#i-have-enabled-the-auto_saveauto_match-parameter-while-selecting-and-it-got-completely-ignored-with-a-warning-message)
-  * [I have done everything as the docs but the auto-matching didn't return anything, what's wrong?](#i-have-done-everything-as-the-docs-but-the-auto-matching-didnt-return-anything-whats-wrong)
-  * [Can Scrapling replace code built on top of BeautifulSoup4?](#can-scrapling-replace-code-built-on-top-of-beautifulsoup4)
-  * [Can Scrapling replace code built on top of AutoScraper?](#can-scrapling-replace-code-built-on-top-of-autoscraper)
-  * [Is Scrapling thread-safe?](#is-scrapling-thread-safe)
-* [More Sponsors!](#more-sponsors)
-* [Contributing](#contributing)
-* [Disclaimer for Scrapling Project](#disclaimer-for-scrapling-project)
-* [License](#license)
-* [Acknowledgments](#acknowledgments)
-* [Thanks and References](#thanks-and-references)
-* [Known Issues](#known-issues)
-
 ## Key Features
 
 ### Fetch websites as you prefer with async support
 - **HTTP Requests**: Fast and stealthy HTTP requests with the `Fetcher` class.
 - **Dynamic Loading & Automation**: Fetch dynamic websites with the `PlayWrightFetcher` class through your real browser, Scrapling's stealth mode, Playwright's Chrome browser, or [NSTbrowser](https://app.nstbrowser.io/r/1vO5e5)'s browserless!
-- **Anti-bot Protections Bypass**: Easily bypass protections with `StealthyFetcher` and `PlayWrightFetcher` classes.
+- **Anti-bot Protections Bypass**: Easily bypass protections with the `StealthyFetcher` and `PlayWrightFetcher` classes.
 
 ### Adaptive Scraping
-- 🔄 **Smart Element Tracking**: Relocate elements after website changes, using an intelligent similarity system and integrated storage.
-- 🎯 **Flexible Selection**: CSS selectors, XPath selectors, filters-based search, text search, regex search and more.
+- 🔄 **Smart Element Tracking**: Relocate elements after website changes using an intelligent similarity system and integrated storage.
+- 🎯 **Flexible Selection**: CSS selectors, XPath selectors, filters-based search, text search, regex search, and more.
 - 🔍 **Find Similar Elements**: Automatically locate elements similar to the element you found!
-- 🧠 **Smart Content Scraping**: Extract data from multiple websites without specific selectors using Scrapling powerful features.
+- 🧠 **Smart Content Scraping**: Extract data from multiple websites using Scrapling's powerful features without specific selectors.
 
 ### High Performance
 - 🚀 **Lightning Fast**: Built from the ground up with performance in mind, outperforming most popular Python scraping libraries.
@@ -114,7 +101,7 @@ Deep SerpApi is a dedicated search engine designed for large language models (LL
 
 ### Developer Friendly
 - 🛠️ **Powerful Navigation API**: Easy DOM traversal in all directions.
-- 🧬 **Rich Text Processing**: All strings have built-in regex, cleaning methods, and more. All elements' attributes are optimized dictionaries that takes less memory than standard dictionaries with added methods.
+- 🧬 **Rich Text Processing**: All strings have built-in regex, cleaning methods, and more. All elements' attributes are optimized dictionaries with added methods that consume less memory than standard dictionaries.
 - 📝 **Auto Selectors Generation**: Generate robust short and full CSS/XPath selectors for any element.
 - 🔌 **Familiar API**: Similar to Scrapy/BeautifulSoup and the same pseudo-elements used in Scrapy.
 - 📘 **Type hints**: Complete type/doc-strings coverage for future-proofing and best autocompletion support.
@@ -124,12 +111,12 @@ Deep SerpApi is a dedicated search engine designed for large language models (LL
 ```python
 from scrapling.fetchers import Fetcher
 
-# Do http GET request to a web page and create an Adaptor instance
+# Do HTTP GET request to a web page and create an Adaptor instance
 page = Fetcher.get('https://quotes.toscrape.com/', stealthy_headers=True)
-# Get all text content from all HTML tags in the page except `script` and `style` tags
+# Get all text content from all HTML tags in the page except the `script` and `style` tags
 page.get_all_text(ignore_tags=('script', 'style'))
 
-# Get all quotes elements, any of these methods will return a list of strings directly (TextHandlers)
+# Get all quotes elements; any of these methods will return a list of strings directly (TextHandlers)
 quotes = page.css('.quote .text::text')  # CSS selector
 quotes = page.xpath('//span[@class="text"]/text()')  # XPath
 quotes = page.css('.quote').css('.text::text')  # Chained selectors
@@ -147,12 +134,15 @@ quotes = page.find_all(['div'], class_='quote')
 quotes = page.find_all(class_='quote')  # and so on...
 
 # Working with elements
-quote.html_content  # Get Inner HTML of this element
+quote.html_content  # Get the Inner HTML of this element
 quote.prettify()  # Prettified version of Inner HTML above
 quote.attrib  # Get that element's attributes
 quote.path  # DOM path to element (List of all ancestors from <html> tag till the element itself)
 ```
 To keep it simple, all methods can be chained on top of each other!
+
+> [!NOTE]
+> Check out the full documentation from [here](https://scrapling.readthedocs.io/en/latest/)
 
 ## Parsing Performance
 
@@ -161,32 +151,45 @@ Here are benchmarks comparing Scrapling to popular Python libraries in two tests
 
 ### Text Extraction Speed Test (5000 nested elements).
 
+This test consists of extracting the text content of 5000 nested div elements.
+
+
 | # |      Library      | Time (ms) | vs Scrapling | 
 |---|:-----------------:|:---------:|:------------:|
-| 1 |     Scrapling     |   5.55    |     1.0x     |
-| 2 |   Parsel/Scrapy   |   5.67    |    1.022x    |
-| 3 |     Raw Lxml      |   6.69    |    1.205x    |
-| 4 |      PyQuery      |   20.84   |    3.755x    |
-| 5 |    Selectolax     |   84.41   |   15.209x    |
-| 6 |   BS4 with Lxml   |  1313.45  |   236.658x   |
-| 7 |  MechanicalSoup   |  1313.66  |   236.695x   |
-| 8 | BS4 with html5lib |  3383.27  |   609.598x   |
+| 1 |     Scrapling     |   5.44    |     1.0x     |
+| 2 |   Parsel/Scrapy   |   5.53    |    1.017x    |
+| 3 |     Raw Lxml      |   6.76    |    1.243x    |
+| 4 |      PyQuery      |   21.96   |    4.037x    |
+| 5 |    Selectolax     |   67.12   |   12.338x    |
+| 6 |   BS4 with Lxml   |  1307.03  |   240.263x   |
+| 7 |  MechanicalSoup   |  1322.64  |   243.132x   |
+| 8 | BS4 with html5lib |  3373.75  |   620.175x   |
 
-As you see, Scrapling is on par with Scrapy and slightly faster than Lxml which both libraries are built on top of. These are the closest results to Scrapling. PyQuery is also built on top of Lxml but still, Scrapling is ~4 times faster.
+As you see, Scrapling is on par with Scrapy and slightly faster than Lxml, which both libraries are built on top of. These are the closest results to Scrapling. PyQuery is also built on top of Lxml, but Scrapling is four times faster.
 
 ### Extraction By Text Speed Test
 
-|   Library   | Time (ms) | vs Scrapling |
-|:-----------:|:---------:|:------------:|
-|  Scrapling  |   2.35    |     1.0x     |
-| AutoScraper |   11.44   |    4.868x    |
+Scrapling can find elements based on its text content and find elements similar to these elements. The only known library with these two features, too, is AutoScraper.
 
-Scrapling can find elements with more methods and it returns full element `Adaptor` objects not only the text like AutoScraper. So, to make this test fair, both libraries will extract an element with text, find similar elements, and then extract the text content for all of them. As you see, Scrapling is still 4.8 times faster at the same task.
+So, we compared this to see how fast Scrapling can be in these two tasks compared to AutoScraper.
+
+Here are the results:
+
+|   Library   | Time (ms) | vs Scrapling |
+|-------------|:---------:|:------------:|
+|  Scrapling  |   2.51    |     1.0x     |
+| AutoScraper |   11.41   |    4.546x    |
+
+Scrapling can find elements with more methods and returns the entire element's `Adaptor` object, not only text like AutoScraper. So, to make this test fair, both libraries will extract an element with text, find similar elements, and then extract the text content for all of them. 
+
+As you see, Scrapling is still 4.5 times faster at the same task. 
+
+If we made Scrapling extract the elements only without stopping to extract each element's text, we would get speed twice as fast as this, but as I said, to make it fair comparison a bit :smile:
 
 > All benchmarks' results are an average of 100 runs. See our [benchmarks.py](https://github.com/D4Vinci/Scrapling/blob/main/benchmarks.py) for methodology and to run your comparisons.
 
 ## Installation
-Scrapling is a breeze to get started with; Starting from version 0.2.9, we require at least Python 3.9 to work.
+Scrapling is a breeze to get started with. Starting from version 0.2.9, we require at least Python 3.9 to work.
 ```bash
 pip3 install scrapling
 ```
@@ -196,600 +199,6 @@ scrapling install
 ```
 If you have any installation issues, please open an issue.
 
-## Fetching Websites
-Fetchers are interfaces built on top of other libraries with added features that do requests or fetch pages for you in a single request fashion and then return an `Adaptor` object. This feature was introduced because the only option we had before was to fetch the page as you wanted it, then pass it manually to the `Adaptor` class to create an `Adaptor` instance and start playing around with the page.
-
-### Features
-You might be slightly confused by now so let me clear things up. All fetcher-type classes are imported in the same way
-```python
->>> from scrapling.fetchers import Fetcher, AsyncFetcher, StealthyFetcher, PlayWrightFetcher
-```
-then use it right away without initializing like this and it will use the default parser settings:
-```python
->>> page = StealthyFetcher.fetch('https://example.com') 
-```
-If you want to configure the parser (Adaptor class) that will be used on the response before returning it for you then do this first:
-```python
->>> StealthyFetcher.configure(auto_match=True, keep_comments=False)
-```
-or
-```python
->>> StealthyFetcher.auto_match = True
->>> StealthyFetcher.keep_comments = False
-```
-Then continue your code as normal.
-
-The available configuration arguments are: `auto_match`, `huge_tree`, `keep_comments`, `keep_cdata`, `storage`, and `storage_args`, which are the same ones you give to the `Adaptor` class. You can display the current configuration anytime by running `<fetcher_class>.display_config()`
-
-Also, the `Response` object returned from all fetchers is the same as the `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, `history`, and `request_headers`. All `cookies`, `headers`, and `request_headers` are always of type `dictionary`.
-> [!NOTE]
-> The `auto_match` argument is disabled by default, you need to enable it to use that feature.
-
-#### Set parser config per request
-As you probably understood, the logic above for setting the parser config will work globally for all requests/fetches done through that class and it's intended.
-
-If your use case requires you to use different config for each request/fetch, then you can pass a dictionary to the request method (`fetch`/`get`/`post`/...) to an argument named `custom_config`.
-
-### Fetcher
-This class is built on top of [httpx](https://www.python-httpx.org/) with additional configuration options, here you can do `GET`, `POST`, `PUT`, and `DELETE` requests.
-
-For all methods, you have `stealthy_headers` which makes `Fetcher` create and use real browser's headers then create a referer header as if this request came from Google's search of this URL's domain. It's enabled by default. You can also set the number of retries with the argument `retries` for all methods and this will make httpx retry requests if it failed for any reason. The default number of retries for all `Fetcher` methods is 3.
-
-> Hence: All headers generated by `stealthy_headers` argument can be overwritten by you through the `headers` argument
-
-You can route all traffic (HTTP and HTTPS) to a proxy for any of these methods in this format `http://username:password@localhost:8030`
-```python
->> page = Fetcher.get('https://httpbin.org/get', stealthy_headers=True, follow_redirects=True)
->> page = Fetcher.post('https://httpbin.org/post', data={'key': 'value'}, proxy='http://username:password@localhost:8030')
->> page = Fetcher.put('https://httpbin.org/put', data={'key': 'value'})
->> page = Fetcher.delete('https://httpbin.org/delete')
-```
-For Async requests, you will just replace the import like below:
-```python
->> from scrapling.fetchers import AsyncFetcher
->> page = await AsyncFetcher.get('https://httpbin.org/get', stealthy_headers=True, follow_redirects=True)
->> page = await AsyncFetcher.post('https://httpbin.org/post', data={'key': 'value'}, proxy='http://username:password@localhost:8030')
->> page = await AsyncFetcher.put('https://httpbin.org/put', data={'key': 'value'})
->> page = await AsyncFetcher.delete('https://httpbin.org/delete')
-```
-### StealthyFetcher
-This class is built on top of [Camoufox](https://github.com/daijro/camoufox), bypassing most anti-bot protections by default. Scrapling adds extra layers of flavors and configurations to increase performance and undetectability even further.
-```python
->> page = StealthyFetcher.fetch('https://www.browserscan.net/bot-detection')  # Running headless by default
->> page.status == 200
-True
->> page = await StealthyFetcher.async_fetch('https://www.browserscan.net/bot-detection')  # the async version of fetch
->> page.status == 200
-True
-```
-> Note: all requests done by this fetcher are waiting by default for all JS to be fully loaded and executed so you don't have to :)
-
-#### The complete list of arguments
-
-|      Argument       | Description                                                                                                                                                                                                                                                                                                                                                                                                     | Optional |
-|:-------------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
-|         url         | Target url                                                                                                                                                                                                                                                                                                                                                                                                      |    ❌     |
-|      headless       | Pass `True` to run the browser in headless/hidden (**default**), `virtual` to run it in virtual screen mode, or `False` for headful/visible mode. The `virtual` mode requires having `xvfb` installed.                                                                                                                                                                                                          |    ✔️    |
-|    block_images     | Prevent the loading of images through Firefox preferences. _This can help save your proxy usage but be careful with this option as it makes some websites never finish loading._                                                                                                                                                                                                                                |    ✔️    |
-|  disable_resources  | Drop requests of unnecessary resources for a speed boost. It depends but it made requests ~25% faster in my tests for some websites.<br/>Requests dropped are of type `font`, `image`, `media`, `beacon`, `object`, `imageset`, `texttrack`, `websocket`, `csp_report`, and `stylesheet`. _This can help save your proxy usage but be careful with this option as it makes some websites never finish loading._ |    ✔️    |
-|    google_search    | Enabled by default, Scrapling will set the referer header to be as if this request came from a Google search for this website's domain name.                                                                                                                                                                                                                                                                    |    ✔️    |
-|    extra_headers    | A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._                                                                                                                                                                                                                                               |    ✔️    |
-|    block_webrtc     | Blocks WebRTC entirely.                                                                                                                                                                                                                                                                                                                                                                                         |    ✔️    |
-|     page_action     | Added for automation. A function that takes the `page` object, does the automation you need, then returns `page` again.                                                                                                                                                                                                                                                                                         |    ✔️    |
-|       addons        | List of Firefox addons to use. **Must be paths to extracted addons.**                                                                                                                                                                                                                                                                                                                                           |    ✔️    |
-|      humanize       | Humanize the cursor movement. Takes either True or the MAX duration in seconds of the cursor movement. The cursor typically takes up to 1.5 seconds to move across the window.                                                                                                                                                                                                                                  |    ✔️    |
-|     allow_webgl     | Enabled by default. Disabling it WebGL not recommended as many WAFs now checks if WebGL is enabled.                                                                                                                                                                                                                                                                                                             |    ✔️    |
-|        geoip        | Recommended to use with proxies; Automatically use IP's longitude, latitude, timezone, country, locale, & spoof the WebRTC IP address. It will also calculate and spoof the browser's language based on the distribution of language speakers in the target region.                                                                                                                                             |    ✔️    |
-|     disable_ads     | Disabled by default, this installs `uBlock Origin` addon on the browser if enabled.                                                                                                                                                                                                                                                                                                                             |    ✔️    |
-|    network_idle     | Wait for the page until there are no network connections for at least 500 ms.                                                                                                                                                                                                                                                                                                                                   |    ✔️    |
-|       timeout       | The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000.                                                                                                                                                                                                                                                                                                    |    ✔️    |
-|    wait_selector    | Wait for a specific css selector to be in a specific state.                                                                                                                                                                                                                                                                                                                                                     |    ✔️    |
-|        proxy        | The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.                                                                                                                                                                                                                                                                                 |    ✔️    |
-|    os_randomize     | If enabled, Scrapling will randomize the OS fingerprints used. The default is Scrapling matching the fingerprints with the current OS.                                                                                                                                                                                                                                                                          |    ✔️    |
-| wait_selector_state | The state to wait for the selector given with `wait_selector`. _Default state is `attached`._                                                                                                                                                                                                                                                                                                                   |    ✔️    |
-
-
-This list isn't final so expect a lot more additions and flexibility to be added in the next versions!
-
-### PlayWrightFetcher
-This class is built on top of [Playwright](https://playwright.dev/python/) which currently provides 4 main run options but they can be mixed as you want.
-```python
->> page = PlayWrightFetcher.fetch('https://www.google.com/search?q=%22Scrapling%22', disable_resources=True)  # Vanilla Playwright option
->> page.css_first("#search a::attr(href)")
-'https://github.com/D4Vinci/Scrapling'
->> page = await PlayWrightFetcher.async_fetch('https://www.google.com/search?q=%22Scrapling%22', disable_resources=True)  # the async version of fetch
->> page.css_first("#search a::attr(href)")
-'https://github.com/D4Vinci/Scrapling'
-```
-> Note: all requests done by this fetcher are waiting by default for all JS to be fully loaded and executed so you don't have to :)
-
-Using this Fetcher class, you can make requests with:
-  1) Vanilla Playwright without any modifications other than the ones you chose.
-  2) Stealthy Playwright with the stealth mode I wrote for it. It's still a WIP but it bypasses many online tests like [Sannysoft's](https://bot.sannysoft.com/).</br> Some of the things this fetcher's stealth mode does include:
-     * Patching the CDP runtime fingerprint.
-     * Mimics some of the real browsers' properties by injecting several JS files and using custom options.
-     * Using custom flags on launch to hide Playwright even more and make it faster.
-     * Generates real browser's headers of the same type and same user OS then append it to the request's headers.
-  3) Real browsers by passing the `real_chrome` argument or the CDP URL of your browser to be controlled by the Fetcher and most of the options can be enabled on it.
-  4) [NSTBrowser](https://app.nstbrowser.io/r/1vO5e5)'s [docker browserless](https://hub.docker.com/r/nstbrowser/browserless) option by passing the CDP URL and enabling `nstbrowser_mode` option.
-
-> Hence using the `real_chrome` argument requires that you have Chrome browser installed on your device
-
-Add that to a lot of controlling/hiding options as you will see in the arguments list below.
-
-#### The complete list of arguments
-
-|      Argument       | Description                                                                                                                                                                                                                                                                                                                                                                                                     | Optional |
-|:-------------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
-|         url         | Target url                                                                                                                                                                                                                                                                                                                                                                                                      |    ❌     |
-|      headless       | Pass `True` to run the browser in headless/hidden (**default**), or `False` for headful/visible mode.                                                                                                                                                                                                                                                                                                           |    ✔️    |
-|  disable_resources  | Drop requests of unnecessary resources for a speed boost. It depends but it made requests ~25% faster in my tests for some websites.<br/>Requests dropped are of type `font`, `image`, `media`, `beacon`, `object`, `imageset`, `texttrack`, `websocket`, `csp_report`, and `stylesheet`. _This can help save your proxy usage but be careful with this option as it makes some websites never finish loading._ |    ✔️    |
-|      useragent      | Pass a useragent string to be used. **Otherwise the fetcher will generate a real Useragent of the same browser and use it.**                                                                                                                                                                                                                                                                                    |    ✔️    |
-|    network_idle     | Wait for the page until there are no network connections for at least 500 ms.                                                                                                                                                                                                                                                                                                                                   |    ✔️    |
-|       timeout       | The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000.                                                                                                                                                                                                                                                                                                    |    ✔️    |
-|     page_action     | Added for automation. A function that takes the `page` object, does the automation you need, then returns `page` again.                                                                                                                                                                                                                                                                                         |    ✔️    |
-|    wait_selector    | Wait for a specific css selector to be in a specific state.                                                                                                                                                                                                                                                                                                                                                     |    ✔️    |
-| wait_selector_state | The state to wait for the selector given with `wait_selector`. _Default state is `attached`._                                                                                                                                                                                                                                                                                                                   |    ✔️    |
-|    google_search    | Enabled by default, Scrapling will set the referer header to be as if this request came from a Google search for this website's domain name.                                                                                                                                                                                                                                                                    |    ✔️    |
-|    extra_headers    | A dictionary of extra headers to add to the request. The referer set by the `google_search` argument takes priority over the referer set here if used together.                                                                                                                                                                                                                                                 |    ✔️    |
-|        proxy        | The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.                                                                                                                                                                                                                                                                                 |    ✔️    |
-|     hide_canvas     | Add random noise to canvas operations to prevent fingerprinting.                                                                                                                                                                                                                                                                                                                                                |    ✔️    |
-|    disable_webgl    | Disables WebGL and WebGL 2.0 support entirely.                                                                                                                                                                                                                                                                                                                                                                  |    ✔️    |
-|       stealth       | Enables stealth mode, always check the documentation to see what stealth mode does currently.                                                                                                                                                                                                                                                                                                                   |    ✔️    |
-|     real_chrome     | If you have Chrome browser installed on your device, enable this and the Fetcher will launch an instance of your browser and use it.                                                                                                                                                                                                                                                                            |    ✔️    |
-|       locale        | Set the locale for the browser if wanted. The default value is `en-US`.                                                                                                                                                                                                                                                                                                                                         |    ✔️    |
-|       cdp_url       | Instead of launching a new browser instance, connect to this CDP URL to control real browsers/NSTBrowser through CDP.                                                                                                                                                                                                                                                                                           |    ✔️    |
-|   nstbrowser_mode   | Enables NSTBrowser mode, **it have to be used with `cdp_url` argument or it will get completely ignored.**                                                                                                                                                                                                                                                                                                      |    ✔️    |
-|  nstbrowser_config  | The config you want to send with requests to the NSTBrowser. _If left empty, Scrapling defaults to an optimized NSTBrowser's docker browserless config._                                                                                                                                                                                                                                                        |    ✔️    |
-
-
-This list isn't final so expect a lot more additions and flexibility to be added in the next versions!
-
-## Advanced Parsing Features
-### Smart Navigation
-```python
->>> quote.tag
-'div'
-
->>> quote.parent
-<data='<div class="col-md-8"> <div class="quote...' parent='<div class="row"> <div class="col-md-8">...'>
-
->>> quote.parent.tag
-'div'
-
->>> quote.children
-[<data='<span class="text" itemprop="text">“The...' parent='<div class="quote" itemscope itemtype="h...'>,
- <data='<span>by <small class="author" itemprop=...' parent='<div class="quote" itemscope itemtype="h...'>,
- <data='<div class="tags"> Tags: <meta class="ke...' parent='<div class="quote" itemscope itemtype="h...'>]
-
->>> quote.siblings
-[<data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
- <data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
-...]
-
->>> quote.next  # gets the next element, the same logic applies to `quote.previous`
-<data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>
-
->>> quote.children.css_first(".author::text")
-'Albert Einstein'
-
->>> quote.has_class('quote')
-True
-
-# Generate new selectors for any element
->>> quote.generate_css_selector
-'body > div > div:nth-of-type(2) > div > div'
-
-# Test these selectors on your favorite browser or reuse them again in the library's methods!
->>> quote.generate_xpath_selector
-'//body/div/div[2]/div/div'
-```
-If your case needs more than the element's parent, you can iterate over the whole ancestors' tree of any element like below
-```python
-for ancestor in quote.iterancestors():
-    # do something with it...
-```
-You can search for a specific ancestor of an element that satisfies a function, all you need to do is to pass a function that takes an `Adaptor` object as an argument and return `True` if the condition satisfies or `False` otherwise like below:
-```python
->>> quote.find_ancestor(lambda ancestor: ancestor.has_class('row'))
-<data='<div class="row"> <div class="col-md-8">...' parent='<div class="container"> <div class="row...'>
-```
-
-### Content-based Selection & Finding Similar Elements
-You can select elements by their text content in multiple ways, here's a full example on another website:
-```python
->>> page = Fetcher.get('https://books.toscrape.com/index.html')
-
->>> page.find_by_text('Tipping the Velvet')  # Find the first element whose text fully matches this text
-<data='<a href="catalogue/tipping-the-velvet_99...' parent='<h3><a href="catalogue/tipping-the-velve...'>
-
->>> page.urljoin(page.find_by_text('Tipping the Velvet').attrib['href'])  # We use `page.urljoin` to return the full URL from the relative `href`
-'https://books.toscrape.com/catalogue/tipping-the-velvet_999/index.html'
-
->>> page.find_by_text('Tipping the Velvet', first_match=False)  # Get all matches if there are more
-[<data='<a href="catalogue/tipping-the-velvet_99...' parent='<h3><a href="catalogue/tipping-the-velve...'>]
-
->>> page.find_by_regex(r'£[\d\.]+')  # Get the first element that its text content matches my price regex
-<data='<p class="price_color">£51.77</p>' parent='<div class="product_price"> <p class="pr...'>
-
->>> page.find_by_regex(r'£[\d\.]+', first_match=False)  # Get all elements that matches my price regex
-[<data='<p class="price_color">£51.77</p>' parent='<div class="product_price"> <p class="pr...'>,
- <data='<p class="price_color">£53.74</p>' parent='<div class="product_price"> <p class="pr...'>,
- <data='<p class="price_color">£50.10</p>' parent='<div class="product_price"> <p class="pr...'>,
- <data='<p class="price_color">£47.82</p>' parent='<div class="product_price"> <p class="pr...'>,
- ...]
-```
-Find all elements that are similar to the current element in location and attributes
-```python
-# For this case, ignore the 'title' attribute while matching
->>> page.find_by_text('Tipping the Velvet').find_similar(ignore_attributes=['title'])
-[<data='<a href="catalogue/a-light-in-the-attic_...' parent='<h3><a href="catalogue/a-light-in-the-at...'>,
- <data='<a href="catalogue/soumission_998/index....' parent='<h3><a href="catalogue/soumission_998/in...'>,
- <data='<a href="catalogue/sharp-objects_997/ind...' parent='<h3><a href="catalogue/sharp-objects_997...'>,
-...]
-
-# You will notice that the number of elements is 19 not 20 because the current element is not included.
->>> len(page.find_by_text('Tipping the Velvet').find_similar(ignore_attributes=['title']))
-19
-
-# Get the `href` attribute from all similar elements
->>> [element.attrib['href'] for element in page.find_by_text('Tipping the Velvet').find_similar(ignore_attributes=['title'])]
-['catalogue/a-light-in-the-attic_1000/index.html',
- 'catalogue/soumission_998/index.html',
- 'catalogue/sharp-objects_997/index.html',
- ...]
-```
-To increase the complexity a little bit, let's say we want to get all books' data using that element as a starting point for some reason
-```python
->>> for product in page.find_by_text('Tipping the Velvet').parent.parent.find_similar():
-        print({
-            "name": product.css_first('h3 a::text'),
-            "price": product.css_first('.price_color').re_first(r'[\d\.]+'),
-            "stock": product.css('.availability::text')[-1].clean()
-        })
-{'name': 'A Light in the ...', 'price': '51.77', 'stock': 'In stock'}
-{'name': 'Soumission', 'price': '50.10', 'stock': 'In stock'}
-{'name': 'Sharp Objects', 'price': '47.82', 'stock': 'In stock'}
-...
-```
-The [documentation](https://github.com/D4Vinci/Scrapling/tree/main/docs/Examples) will provide more advanced examples.
-
-### Handling Structural Changes
-Let's say you are scraping a page with a structure like this:
-```html
-<div class="container">
-    <section class="products">
-        <article class="product" id="p1">
-            <h3>Product 1</h3>
-            <p class="description">Description 1</p>
-        </article>
-        <article class="product" id="p2">
-            <h3>Product 2</h3>
-            <p class="description">Description 2</p>
-        </article>
-    </section>
-</div>
-```
-And you want to scrape the first product, the one with the `p1` ID. You will probably write a selector like this
-```python
-page.css('#p1')
-```
-When website owners implement structural changes like
-```html
-<div class="new-container">
-    <div class="product-wrapper">
-        <section class="products">
-            <article class="product new-class" data-id="p1">
-                <div class="product-info">
-                    <h3>Product 1</h3>
-                    <p class="new-description">Description 1</p>
-                </div>
-            </article>
-            <article class="product new-class" data-id="p2">
-                <div class="product-info">
-                    <h3>Product 2</h3>
-                    <p class="new-description">Description 2</p>
-                </div>
-            </article>
-        </section>
-    </div>
-</div>
-```
-The selector will no longer function and your code needs maintenance. That's where Scrapling's auto-matching feature comes into play.
-
-```python
-from scrapling.parser import Adaptor
-# Before the change
-page = Adaptor(page_source, auto_match=True, url='example.com')
-element = page.css('#p1' auto_save=True)
-if not element:  # One day website changes?
-    element = page.css('#p1', auto_match=True)  # Scrapling still finds it!
-# the rest of the code...
-```
-> How does the auto-matching work? Check the [FAQs](#-enlightening-questions-and-faqs) section for that and other possible issues while auto-matching.
-
-#### Real-World Scenario
-Let's use a real website as an example and use one of the fetchers to fetch its source. To do this we need to find a website that will change its design/structure soon, take a copy of its source then wait for the website to make the change. Of course, that's nearly impossible to know unless I know the website's owner but that will make it a staged test haha.
-
-To solve this issue, I will use [The Web Archive](https://archive.org/)'s [Wayback Machine](https://web.archive.org/). Here is a copy of [StackOverFlow's website in 2010](https://web.archive.org/web/20100102003420/http://stackoverflow.com/), pretty old huh?</br>Let's test if the automatch feature can extract the same button in the old design from 2010 and the current design using the same selector :)
-
-If I want to extract the Questions button from the old design I can use a selector like this `#hmenus > div:nth-child(1) > ul > li:nth-child(1) > a` This selector is too specific because it was generated by Google Chrome.
-Now let's test the same selector in both versions
-```python
->> from scrapling.fetchers import Fetcher
->> selector = '#hmenus > div:nth-child(1) > ul > li:nth-child(1) > a'
->> old_url = "https://web.archive.org/web/20100102003420/http://stackoverflow.com/"
->> new_url = "https://stackoverflow.com/"
->> Fetcher.configure(auto_match=True, automatch_domain='stackoverflow.com')
->> 
->> page = Fetcher.get(old_url, timeout=30)
->> element1 = page.css_first(selector, auto_save=True)
->> 
->> # Same selector but used in the updated website
->> page = Fetcher.get(new_url)
->> element2 = page.css_first(selector, auto_match=True)
->> 
->> if element1.text == element2.text:
-...    print('Scrapling found the same element in the old design and the new design!')
-'Scrapling found the same element in the old design and the new design!'
-```
-Note that I used a new argument called `automatch_domain`, this is because for Scrapling these are two different URLs, not the website so it isolates their data. To tell Scrapling they are the same website, we then pass the domain we want to use for saving auto-match data for them both so Scrapling doesn't isolate them.
-
-In a real-world scenario, the code will be the same except it will use the same URL for both requests so you won't need to use the `automatch_domain` argument. This is the closest example I can give to real-world cases so I hope it didn't confuse you :)
-
-**Notes:**
-1. For the two examples above I used one time the `Adaptor` class and the second time the `Fetcher` class just to show you that you can create the `Adaptor` object by yourself if you have the source or fetch the source using any `Fetcher` class then it will create the `Adaptor` object for you.
-2. Passing the `auto_save` argument with the `auto_match` argument set to `False` while initializing the Adaptor/Fetcher object will only result in ignoring the `auto_save` argument value and the following warning message
-    ```text
-    Argument `auto_save` will be ignored because `auto_match` wasn't enabled on initialization. Check docs for more info.
-    ```
-    This behavior is purely for performance reasons so the database gets created/connected only when you are planning to use the auto-matching features. Same case with the `auto_match` argument.
-
-3. The `auto_match` parameter works only for `Adaptor` instances not `Adaptors` so if you do something like this you will get an error
-    ```python
-    page.css('body').css('#p1', auto_match=True)
-    ```
-    because you can't auto-match a whole list, you have to be specific and do something like
-    ```python
-    page.css_first('body').css('#p1', auto_match=True)
-    ```
-
-### Find elements by filters
-Inspired by BeautifulSoup's `find_all` function you can find elements by using `find_all`/`find` methods. Both methods can take multiple types of filters and return all elements in the pages that all these filters apply to.
-
-* To be more specific:
-  * Any string passed is considered a tag name 
-  * Any iterable passed like List/Tuple/Set is considered an iterable of tag names.
-  * Any dictionary is considered a mapping of HTML element(s) attribute names and attribute values.
-  * Any regex patterns passed are used as filters to elements by their text content
-  * Any functions passed are used as filters
-  * Any keyword argument passed is considered as an HTML element attribute with its value.
-
-So the way it works is after collecting all passed arguments and keywords, each filter passes its results to the following filter in a waterfall-like filtering system.
-<br/>It filters all elements in the current page/element in the following order:
-
-1. All elements with the passed tag name(s).
-2. All elements that match all passed attribute(s).
-3. All elements that its text content match all passed regex patterns.
-4. All elements that fulfill all passed function(s).
-
-Note: The filtering process always starts from the first filter it finds in the filtering order above so if no tag name(s) are passed but attributes are passed, the process starts from that layer and so on. **But the order in which you pass the arguments doesn't matter.**
-
-Examples to clear any confusion :)
-
-```python
->> from scrapling.fetchers import Fetcher
->> page = Fetcher.get('https://quotes.toscrape.com/')
-# Find all elements with tag name `div`.
->> page.find_all('div')
-[<data='<div class="container"> <div class="row...' parent='<body> <div class="container"> <div clas...'>,
- <data='<div class="row header-box"> <div class=...' parent='<div class="container"> <div class="row...'>,
-...]
-
-# Find all div elements with a class that equals `quote`.
->> page.find_all('div', class_='quote')
-[<data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
- <data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
-...]
-
-# Same as above.
->> page.find_all('div', {'class': 'quote'})
-[<data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
- <data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
-...]
-
-# Find all elements with a class that equals `quote`.
->> page.find_all({'class': 'quote'})
-[<data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
- <data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
-...]
-
-# Find all div elements with a class that equals `quote`, and contains the element `.text` which contains the word 'world' in its content.
->> page.find_all('div', {'class': 'quote'}, lambda e: "world" in e.css_first('.text::text'))
-[<data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>]
-
-# Find all elements that don't have children.
->> page.find_all(lambda element: len(element.children) > 0)
-[<data='<html lang="en"><head><meta charset="UTF...'>,
- <data='<head><meta charset="UTF-8"><title>Quote...' parent='<html lang="en"><head><meta charset="UTF...'>,
- <data='<body> <div class="container"> <div clas...' parent='<html lang="en"><head><meta charset="UTF...'>,
-...]
-
-# Find all elements that contain the word 'world' in its content.
->> page.find_all(lambda element: "world" in element.text)
-[<data='<span class="text" itemprop="text">“The...' parent='<div class="quote" itemscope itemtype="h...'>,
- <data='<a class="tag" href="/tag/world/page/1/"...' parent='<div class="tags"> Tags: <meta class="ke...'>]
-
-# Find all span elements that match the given regex
->> page.find_all('span', re.compile(r'world'))
-[<data='<span class="text" itemprop="text">“The...' parent='<div class="quote" itemscope itemtype="h...'>]
-
-# Find all div and span elements with class 'quote' (No span elements like that so only div returned)
->> page.find_all(['div', 'span'], {'class': 'quote'})
-[<data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
- <data='<div class="quote" itemscope itemtype="h...' parent='<div class="col-md-8"> <div class="quote...'>,
-...]
-
-# Mix things up
->> page.find_all({'itemtype':"http://schema.org/CreativeWork"}, 'div').css('.author::text')
-['Albert Einstein',
- 'J.K. Rowling',
-...]
-```
-
-### Is That All?
-Here's what else you can do with Scrapling:
-
-- Accessing the `lxml.etree` object itself of any element directly
-    ```python
-    >>> quote._root
-    <Element div at 0x107f98870>
-    ```
-- Saving and retrieving elements manually to auto-match them outside the `css` and the `xpath` methods but you have to set the identifier by yourself.
-
-  - To save an element to the database:
-    ```python
-    >>> element = page.find_by_text('Tipping the Velvet', first_match=True)
-    >>> page.save(element, 'my_special_element')
-    ```
-  - Now later when you want to retrieve it and relocate it inside the page with auto-matching, it would be like this
-    ```python
-    >>> element_dict = page.retrieve('my_special_element')
-    >>> page.relocate(element_dict, adaptor_type=True)
-    [<data='<a href="catalogue/tipping-the-velvet_99...' parent='<h3><a href="catalogue/tipping-the-velve...'>]
-    >>> page.relocate(element_dict, adaptor_type=True).css('::text')
-    ['Tipping the Velvet']
-    ```
-  - if you want to keep it as `lxml.etree` object, leave the `adaptor_type` argument
-    ```python
-    >>> page.relocate(element_dict)
-    [<Element a at 0x105a2a7b0>]
-    ```
-
-- Filtering results based on a function
-```python
-# Find all products over $50
-expensive_products = page.css('.product_pod').filter(
-    lambda p: float(p.css('.price_color').re_first(r'[\d\.]+')) > 50
-)
-```
-
-- Searching results for the first one that matches a function
-```python
-# Find all the products with price '53.23'
-page.css('.product_pod').search(
-    lambda p: float(p.css('.price_color').re_first(r'[\d\.]+')) == 54.23
-)
-```
-
-- Doing operations on element content is the same as scrapy
-    ```python
-    quote.re(r'regex_pattern')  # Get all strings (TextHandlers) that match the regex pattern
-    quote.re_first(r'regex_pattern')  # Get the first string (TextHandler) only
-    quote.json()  # If the content text is jsonable, then convert it to json using `orjson` which is 10x faster than the standard json library and provides more options
-    ```
-    except that you can do more with them like
-    ```python
-    quote.re(
-        r'regex_pattern',
-        replace_entities=True,  # Character entity references are replaced by their corresponding character
-        clean_match=True,       # This will ignore all whitespaces and consecutive spaces while matching
-        case_sensitive= False,  # Set the regex to ignore letters case while compiling it
-    )
-    ```
-    Hence all of these methods are methods from the `TextHandler` within that contains the text content so the same can be done directly if you call the `.text` property or equivalent selector function.
-
-
-- Doing operations on the text content itself includes
-  - Cleaning the text from any white spaces and replacing consecutive spaces with single space
-    ```python
-    quote.clean()
-    ```
-  - You already know about the regex matching and the fast json parsing but did you know that all strings returned from the regex search are actually `TextHandler` objects too? so in cases where you have for example a JS object assigned to a JS variable inside JS code and want to extract it with regex and then convert it to json object, in other libraries, these would be more than 1 line of code but here you can do it in 1 line like this
-    ```python
-    page.xpath('//script/text()').re_first(r'var dataLayer = (.+);').json()
-    ```
-  - Sort all characters in the string as if it were a list and return the new string
-    ```python
-    quote.sort(reverse=False)
-    ```
-  > To be clear, `TextHandler` is a sub-class of Python's `str` so all normal operations/methods that work with Python strings will work with it.
-
-- Any element's attributes are not exactly a dictionary but a sub-class of [mapping](https://docs.python.org/3/glossary.html#term-mapping) called `AttributesHandler` that's read-only so it's faster and string values returned are actually `TextHandler` objects so all operations above can be done on them, standard dictionary operations that don't modify the data, and more :)
-  - Unlike standard dictionaries, here you can search by values too and can do partial searches. It might be handy in some cases (returns a generator of matches)
-    ```python
-    >>> for item in element.attrib.search_values('catalogue', partial=True):
-            print(item)
-    {'href': 'catalogue/tipping-the-velvet_999/index.html'}
-    ```
-  - Serialize the current attributes to JSON bytes:
-    ```python
-    >>> element.attrib.json_string
-    b'{"href":"catalogue/tipping-the-velvet_999/index.html","title":"Tipping the Velvet"}'
-    ```
-  - Converting it to a normal dictionary
-    ```python
-    >>> dict(element.attrib)
-    {'href': 'catalogue/tipping-the-velvet_999/index.html',
-    'title': 'Tipping the Velvet'}
-    ```
-
-Scrapling is under active development so expect many more features coming soon :)
-
-## More Advanced Usage
-
-There are a lot of deep details skipped here to make this as short as possible so to take a deep dive, head to the [docs](https://github.com/D4Vinci/Scrapling/tree/main/docs) section. I will try to keep it updated as possible and add complex examples. There I will explain points like how to write your storage system, write spiders that don't depend on selectors at all, and more...
-
-Note that implementing your storage system can be complex as there are some strict rules such as inheriting from the same abstract class, following the singleton design pattern used in other classes, and more. So make sure to read the docs first.
-
-> [!IMPORTANT] 
-> A website is needed to provide detailed library documentation.<br/> 
-> I'm trying to rush creating the website, researching new ideas, and adding more features/tests/benchmarks but time is tight with too many spinning plates between work, personal life, and working on Scrapling. I have been working on Scrapling for months for free after all.<br/><br/>
-> If you like `Scrapling` and want it to keep improving then this is a friendly reminder that you can help by supporting me through the [sponsor button](https://github.com/sponsors/D4Vinci).
-
-## ⚡ Enlightening Questions and FAQs
-This section addresses common questions about Scrapling, please read this section before opening an issue.
-
-### How does auto-matching work?
-  1. You need to get a working selector and run it at least once with methods `css` or `xpath` with the `auto_save` parameter set to `True` before structural changes happen.
-  2. Before returning results for you, Scrapling uses its configured database and saves unique properties about that element.
-  3. Now because everything about the element can be changed or removed, nothing from the element can be used as a unique identifier for the database. To solve this issue, I made the storage system rely on two things:
-     1. The domain of the URL you gave while initializing the first Adaptor object
-     2. The `identifier` parameter you passed to the method while selecting. If you didn't pass one, then the selector string itself will be used as an identifier but remember you will have to use it as an identifier value later when the structure changes and you want to pass the new selector.
-
-     Together both are used to retrieve the element's unique properties from the database later.
-  4. Now later when you enable the `auto_match` parameter for both the Adaptor instance and the method call. The element properties are retrieved and Scrapling loops over all elements in the page and compares each one's unique properties to the unique properties we already have for this element and a score is calculated for each one.
-  5. Comparing elements is not exact but more about finding how similar these values are, so everything is taken into consideration, even the values' order, like the order in which the element class names were written before and the order in which the same element class names are written now.
-  6. The score for each element is stored in the table, and the element(s) with the highest combined similarity scores are returned.
-
-### How does the auto-matching work if I didn't pass a URL while initializing the Adaptor object?
-Not a big problem as it depends on your usage. The word `default` will be used in place of the URL field while saving the element's unique properties. So this will only be an issue if you used the same identifier later for a different website that you didn't pass the URL parameter while initializing it as well. The save process will overwrite the previous data and auto-matching uses the latest saved properties only.
-
-### If all things about an element can change or get removed, what are the unique properties to be saved?
-For each element, Scrapling will extract:
-- Element tag name, text, attributes (names and values), siblings (tag names only), and path (tag names only).
-- Element's parent tag name, attributes (names and values), and text.
-
-### I have enabled the `auto_save`/`auto_match` parameter while selecting and it got completely ignored with a warning message
-That's because passing the `auto_save`/`auto_match` argument without setting `auto_match` to `True` while initializing the Adaptor object will only result in ignoring the `auto_save`/`auto_match` argument value. This behavior is purely for performance reasons so the database gets created only when you are planning to use the auto-matching features.
-
-### I have done everything as the docs but the auto-matching didn't return anything, what's wrong?
-It could be one of these reasons:
-1. No data were saved/stored for this element before.
-2. The selector passed is not the one used while storing element data. The solution is simple
-   - Pass the old selector again as an identifier to the method called.
-   - Retrieve the element with the retrieve method using the old selector as identifier then save it again with the save method and the new selector as identifier.
-   - Start using the identifier argument more often if you are planning to use every new selector from now on.
-3. The website had some extreme structural changes like a new full design. If this happens a lot with this website, the solution would be to make your code as selector-free as possible using Scrapling features.
-
-### Can Scrapling replace code built on top of BeautifulSoup4?
-Pretty much yeah, almost all features you get from BeautifulSoup can be found or achieved in Scrapling one way or another. In fact, if you see there's a feature in bs4 that is missing in Scrapling, please make a feature request from the issues tab to let me know.
-
-### Can Scrapling replace code built on top of AutoScraper?
-Of course, you can find elements by text/regex, find similar elements in a more reliable way than AutoScraper, and finally save/retrieve elements manually to use later as the model feature in AutoScraper. I have pulled all top articles about AutoScraper from Google and tested Scrapling against examples in them. In all examples, Scrapling got the same results as AutoScraper in much less time.
-
-### Is Scrapling thread-safe?
-Yes, Scrapling instances are thread-safe. Each Adaptor instance maintains its state.
 
 ## More Sponsors!
 <a href="https://serpapi.com/?utm_source=scrapling"><img src="https://raw.githubusercontent.com/D4Vinci/Scrapling/main/images/SerpApi.png" height="500" alt="SerpApi Banner" ></a>
@@ -802,7 +211,7 @@ Please read the [contributing file](https://github.com/D4Vinci/Scrapling/blob/ma
 
 ## Disclaimer for Scrapling Project
 > [!CAUTION]
-> This library is provided for educational and research purposes only. By using this library, you agree to comply with local and international laws regarding data scraping and privacy. The authors and contributors are not responsible for any misuse of this software. This library should not be used to violate the rights of others, for unethical purposes, or to use data in an unauthorized or illegal manner. Do not use it on any website unless you have permission from the website owner or within their allowed rules like the `robots.txt` file, for example.
+> This library is provided for educational and research purposes only. By using this library, you agree to comply with local and international data scraping and privacy laws. The authors and contributors are not responsible for any misuse of this software. This library should not be used to violate the rights of others, for unethical purposes, or to use data in an unauthorized or illegal manner. Do not use it on any website unless you have permission from the website owner or within their allowed rules, such as the `robots.txt` file.
 
 ## License
 This work is licensed under BSD-3
@@ -819,7 +228,7 @@ This project includes code adapted from:
 - [rebrowser-patches](https://github.com/rebrowser/rebrowser-patches)
 
 ## Known Issues
-- In the auto-matching save process, the unique properties of the first element from the selection results are the only ones that get saved. So if the selector you are using selects different elements on the page that are in different locations, auto-matching will probably return to you the first element only when you relocate it later. This doesn't include combined CSS selectors (Using commas to combine more than one selector for example) as these selectors get separated and each selector gets executed alone.
+- In the auto-matching save process, the unique properties of the first element from the selection results are the only ones that get saved. If the selector you are using selects different elements on the page in different locations, auto-matching will return the first element to you only when you relocate it later. This doesn't include combined CSS selectors (Using commas to combine more than one selector, for example), as these selectors get separated, and each selector gets executed alone.
 
 ---
 <div align="center"><small>Designed & crafted with ❤️ by Karim Shoair.</small></div><br>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Dealing with failing web scrapers due to anti-bot protections or website changes
 Scrapling is a high-performance, intelligent web scraping library for Python that automatically adapts to website changes while significantly outperforming popular alternatives. For both beginners and experts, Scrapling provides powerful features while maintaining simplicity.
 
 ```python
->> from scrapling.defaults import Fetcher, AsyncFetcher, StealthyFetcher, PlayWrightFetcher
+>> from scrapling.fetchers import Fetcher, AsyncFetcher, StealthyFetcher, PlayWrightFetcher
 # Fetch websites' source under the radar!
 >> page = StealthyFetcher.fetch('https://example.com', headless=True, network_idle=True)
 >> print(page.status)
@@ -200,18 +200,24 @@ Fetchers are interfaces built on top of other libraries with added features that
 ### Features
 You might be slightly confused by now so let me clear things up. All fetcher-type classes are imported in the same way
 ```python
-from scrapling.fetchers import Fetcher, StealthyFetcher, PlayWrightFetcher
+>>> from scrapling.fetchers import Fetcher, AsyncFetcher, StealthyFetcher, PlayWrightFetcher
 ```
-All of them can take these initialization arguments: `auto_match`, `huge_tree`, `keep_comments`, `keep_cdata`, `storage`, and `storage_args`, which are the same ones you give to the `Adaptor` class.
+then use it right away without initializing like this and it will use the default parser settings:
+```python
+>>> page = StealthyFetcher.fetch('https://example.com') 
+```
+If you want to configure the parser (Adaptor class) that will be used on the response before returning it for you then do this first:
+```python
+>>> StealthyFetcher.configure(auto_match=True, keep_comments=False)
+```
+or
+```python
+>>> StealthyFetcher.auto_match = True
+>>> StealthyFetcher.keep_comments = False
+```
+Then continue your code as normal.
 
-If you don't want to pass arguments to the generated `Adaptor` object and want to use the default values, you can use this import instead for cleaner code:
-```python
-from scrapling.defaults import Fetcher, AsyncFetcher, StealthyFetcher, PlayWrightFetcher
-```
-then use it right away without initializing like:
-```python
-page = StealthyFetcher.fetch('https://example.com') 
-```
+The available configuration arguments are: `auto_match`, `huge_tree`, `keep_comments`, `keep_cdata`, `storage`, and `storage_args`, which are the same ones you give to the `Adaptor` class.
 
 Also, the `Response` object returned from all fetchers is the same as the `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, `history`, and `request_headers`. All `cookies`, `headers`, and `request_headers` are always of type `dictionary`.
 > [!NOTE]
@@ -225,26 +231,26 @@ For all methods, you have `stealthy_headers` which makes `Fetcher` create and us
 
 You can route all traffic (HTTP and HTTPS) to a proxy for any of these methods in this format `http://username:password@localhost:8030`
 ```python
->> page = Fetcher().get('https://httpbin.org/get', stealthy_headers=True, follow_redirects=True)
->> page = Fetcher().post('https://httpbin.org/post', data={'key': 'value'}, proxy='http://username:password@localhost:8030')
->> page = Fetcher().put('https://httpbin.org/put', data={'key': 'value'})
->> page = Fetcher().delete('https://httpbin.org/delete')
+>> page = Fetcher.get('https://httpbin.org/get', stealthy_headers=True, follow_redirects=True)
+>> page = Fetcher.post('https://httpbin.org/post', data={'key': 'value'}, proxy='http://username:password@localhost:8030')
+>> page = Fetcher.put('https://httpbin.org/put', data={'key': 'value'})
+>> page = Fetcher.delete('https://httpbin.org/delete')
 ```
 For Async requests, you will just replace the import like below:
 ```python
 >> from scrapling.fetchers import AsyncFetcher
->> page = await AsyncFetcher().get('https://httpbin.org/get', stealthy_headers=True, follow_redirects=True)
->> page = await AsyncFetcher().post('https://httpbin.org/post', data={'key': 'value'}, proxy='http://username:password@localhost:8030')
->> page = await AsyncFetcher().put('https://httpbin.org/put', data={'key': 'value'})
->> page = await AsyncFetcher().delete('https://httpbin.org/delete')
+>> page = await AsyncFetcher.get('https://httpbin.org/get', stealthy_headers=True, follow_redirects=True)
+>> page = await AsyncFetcher.post('https://httpbin.org/post', data={'key': 'value'}, proxy='http://username:password@localhost:8030')
+>> page = await AsyncFetcher.put('https://httpbin.org/put', data={'key': 'value'})
+>> page = await AsyncFetcher.delete('https://httpbin.org/delete')
 ```
 ### StealthyFetcher
 This class is built on top of [Camoufox](https://github.com/daijro/camoufox), bypassing most anti-bot protections by default. Scrapling adds extra layers of flavors and configurations to increase performance and undetectability even further.
 ```python
->> page = StealthyFetcher().fetch('https://www.browserscan.net/bot-detection')  # Running headless by default
+>> page = StealthyFetcher.fetch('https://www.browserscan.net/bot-detection')  # Running headless by default
 >> page.status == 200
 True
->> page = await StealthyFetcher().async_fetch('https://www.browserscan.net/bot-detection')  # the async version of fetch
+>> page = await StealthyFetcher.async_fetch('https://www.browserscan.net/bot-detection')  # the async version of fetch
 >> page.status == 200
 True
 ```
@@ -281,10 +287,10 @@ This list isn't final so expect a lot more additions and flexibility to be added
 ### PlayWrightFetcher
 This class is built on top of [Playwright](https://playwright.dev/python/) which currently provides 4 main run options but they can be mixed as you want.
 ```python
->> page = PlayWrightFetcher().fetch('https://www.google.com/search?q=%22Scrapling%22', disable_resources=True)  # Vanilla Playwright option
+>> page = PlayWrightFetcher.fetch('https://www.google.com/search?q=%22Scrapling%22', disable_resources=True)  # Vanilla Playwright option
 >> page.css_first("#search a::attr(href)")
 'https://github.com/D4Vinci/Scrapling'
->> page = await PlayWrightFetcher().async_fetch('https://www.google.com/search?q=%22Scrapling%22', disable_resources=True)  # the async version of fetch
+>> page = await PlayWrightFetcher.async_fetch('https://www.google.com/search?q=%22Scrapling%22', disable_resources=True)  # the async version of fetch
 >> page.css_first("#search a::attr(href)")
 'https://github.com/D4Vinci/Scrapling'
 ```
@@ -386,7 +392,7 @@ You can search for a specific ancestor of an element that satisfies a function, 
 ### Content-based Selection & Finding Similar Elements
 You can select elements by their text content in multiple ways, here's a full example on another website:
 ```python
->>> page = Fetcher().get('https://books.toscrape.com/index.html')
+>>> page = Fetcher.get('https://books.toscrape.com/index.html')
 
 >>> page.find_by_text('Tipping the Velvet')  # Find the first element whose text fully matches this text
 <data='<a href="catalogue/tipping-the-velvet_99...' parent='<h3><a href="catalogue/tipping-the-velve...'>
@@ -566,7 +572,7 @@ Examples to clear any confusion :)
 
 ```python
 >> from scrapling.fetchers import Fetcher
->> page = Fetcher().get('https://quotes.toscrape.com/')
+>> page = Fetcher.get('https://quotes.toscrape.com/')
 # Find all elements with tag name `div`.
 >> page.find_all('div')
 [<data='<div class="container"> <div class="row...' parent='<body> <div class="container"> <div clas...'>,

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Scrapling is a high-performance, intelligent web scraping library for Python tha
 
 ```python
 >> from scrapling.fetchers import Fetcher, AsyncFetcher, StealthyFetcher, PlayWrightFetcher
+>> StealthyFetcher.auto_match = True
 # Fetch websites' source under the radar!
 >> page = StealthyFetcher.fetch('https://example.com', headless=True, network_idle=True)
 >> print(page.status)
@@ -50,45 +51,48 @@ Deep SerpApi is a dedicated search engine designed for large language models (LL
 ---
 
 ## Table of content
-  * [Key Features](#key-features)
-    * [Fetch websites as you prefer](#fetch-websites-as-you-prefer-with-async-support)
-    * [Adaptive Scraping](#adaptive-scraping)
-    * [Performance](#performance)
-    * [Developing Experience](#developing-experience)
-  * [Getting Started](#getting-started)
-  * [Parsing Performance](#parsing-performance)
-    * [Text Extraction Speed Test (5000 nested elements).](#text-extraction-speed-test-5000-nested-elements)
-    * [Extraction By Text Speed Test](#extraction-by-text-speed-test)
-  * [Installation](#installation)
-  * [Fetching Websites](#fetching-websites)
-    * [Features](#features)
-    * [Fetcher class](#fetcher)
-    * [StealthyFetcher class](#stealthyfetcher)
-    * [PlayWrightFetcher class](#playwrightfetcher)
-  * [Advanced Parsing Features](#advanced-parsing-features)
-    * [Smart Navigation](#smart-navigation)
-    * [Content-based Selection & Finding Similar Elements](#content-based-selection--finding-similar-elements)
-    * [Handling Structural Changes](#handling-structural-changes)
-      * [Real World Scenario](#real-world-scenario)
-    * [Find elements by filters](#find-elements-by-filters)
-    * [Is That All?](#is-that-all)
-  * [More Advanced Usage](#more-advanced-usage)
-  * [⚡ Enlightening Questions and FAQs](#-enlightening-questions-and-faqs)
-    * [How does auto-matching work?](#how-does-auto-matching-work)
-    * [How does the auto-matching work if I didn't pass a URL while initializing the Adaptor object?](#how-does-the-auto-matching-work-if-i-didnt-pass-a-url-while-initializing-the-adaptor-object)
-    * [If all things about an element can change or get removed, what are the unique properties to be saved?](#if-all-things-about-an-element-can-change-or-get-removed-what-are-the-unique-properties-to-be-saved)
-    * [I have enabled the `auto_save`/`auto_match` parameter while selecting and it got completely ignored with a warning message](#i-have-enabled-the-auto_saveauto_match-parameter-while-selecting-and-it-got-completely-ignored-with-a-warning-message)
-    * [I have done everything as the docs but the auto-matching didn't return anything, what's wrong?](#i-have-done-everything-as-the-docs-but-the-auto-matching-didnt-return-anything-whats-wrong)
-    * [Can Scrapling replace code built on top of BeautifulSoup4?](#can-scrapling-replace-code-built-on-top-of-beautifulsoup4)
-    * [Can Scrapling replace code built on top of AutoScraper?](#can-scrapling-replace-code-built-on-top-of-autoscraper)
-    * [Is Scrapling thread-safe?](#is-scrapling-thread-safe)
-  * [More Sponsors!](#more-sponsors)
-  * [Contributing](#contributing)
-  * [Disclaimer for Scrapling Project](#disclaimer-for-scrapling-project)
-  * [License](#license)
-  * [Acknowledgments](#acknowledgments)
-  * [Thanks and References](#thanks-and-references)
-  * [Known Issues](#known-issues)
+* [Key Features](#key-features)
+  * [Fetch websites as you prefer with async support](#fetch-websites-as-you-prefer-with-async-support)
+  * [Adaptive Scraping](#adaptive-scraping)
+  * [High Performance](#high-performance)
+  * [Developer Friendly](#developer-friendly)
+* [Getting Started](#getting-started)
+* [Parsing Performance](#parsing-performance)
+  * [Text Extraction Speed Test (5000 nested elements).](#text-extraction-speed-test-5000-nested-elements)
+  * [Extraction By Text Speed Test](#extraction-by-text-speed-test)
+* [Installation](#installation)
+* [Fetching Websites](#fetching-websites)
+  * [Features](#features)
+    * [Set parser config per request](#set-parser-config-per-request)
+  * [Fetcher](#fetcher)
+  * [StealthyFetcher](#stealthyfetcher)
+    * [The complete list of arguments](#the-complete-list-of-arguments)
+  * [PlayWrightFetcher](#playwrightfetcher)
+    * [The complete list of arguments](#the-complete-list-of-arguments-1)
+* [Advanced Parsing Features](#advanced-parsing-features)
+  * [Smart Navigation](#smart-navigation)
+  * [Content-based Selection & Finding Similar Elements](#content-based-selection--finding-similar-elements)
+  * [Handling Structural Changes](#handling-structural-changes)
+    * [Real-World Scenario](#real-world-scenario)
+  * [Find elements by filters](#find-elements-by-filters)
+  * [Is That All?](#is-that-all)
+* [More Advanced Usage](#more-advanced-usage)
+* [⚡ Enlightening Questions and FAQs](#-enlightening-questions-and-faqs)
+  * [How does auto-matching work?](#how-does-auto-matching-work)
+  * [How does the auto-matching work if I didn't pass a URL while initializing the Adaptor object?](#how-does-the-auto-matching-work-if-i-didnt-pass-a-url-while-initializing-the-adaptor-object)
+  * [If all things about an element can change or get removed, what are the unique properties to be saved?](#if-all-things-about-an-element-can-change-or-get-removed-what-are-the-unique-properties-to-be-saved)
+  * [I have enabled the `auto_save`/`auto_match` parameter while selecting and it got completely ignored with a warning message](#i-have-enabled-the-auto_saveauto_match-parameter-while-selecting-and-it-got-completely-ignored-with-a-warning-message)
+  * [I have done everything as the docs but the auto-matching didn't return anything, what's wrong?](#i-have-done-everything-as-the-docs-but-the-auto-matching-didnt-return-anything-whats-wrong)
+  * [Can Scrapling replace code built on top of BeautifulSoup4?](#can-scrapling-replace-code-built-on-top-of-beautifulsoup4)
+  * [Can Scrapling replace code built on top of AutoScraper?](#can-scrapling-replace-code-built-on-top-of-autoscraper)
+  * [Is Scrapling thread-safe?](#is-scrapling-thread-safe)
+* [More Sponsors!](#more-sponsors)
+* [Contributing](#contributing)
+* [Disclaimer for Scrapling Project](#disclaimer-for-scrapling-project)
+* [License](#license)
+* [Acknowledgments](#acknowledgments)
+* [Thanks and References](#thanks-and-references)
+* [Known Issues](#known-issues)
 
 ## Key Features
 
@@ -120,10 +124,8 @@ Deep SerpApi is a dedicated search engine designed for large language models (LL
 ```python
 from scrapling.fetchers import Fetcher
 
-fetcher = Fetcher(auto_match=False)
-
 # Do http GET request to a web page and create an Adaptor instance
-page = fetcher.get('https://quotes.toscrape.com/', stealthy_headers=True)
+page = Fetcher.get('https://quotes.toscrape.com/', stealthy_headers=True)
 # Get all text content from all HTML tags in the page except `script` and `style` tags
 page.get_all_text(ignore_tags=('script', 'style'))
 
@@ -221,7 +223,7 @@ The available configuration arguments are: `auto_match`, `huge_tree`, `keep_comm
 
 Also, the `Response` object returned from all fetchers is the same as the `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, `history`, and `request_headers`. All `cookies`, `headers`, and `request_headers` are always of type `dictionary`.
 > [!NOTE]
-> The `auto_match` argument is enabled by default which is the one you should care about the most as you will see later.
+> The `auto_match` argument is disabled by default, you need to enable it to use that feature.
 
 #### Set parser config per request
 As you probably understood, the logic above for setting the parser config will work globally for all requests/fetches done through that class and it's intended.
@@ -262,7 +264,7 @@ True
 ```
 > Note: all requests done by this fetcher are waiting by default for all JS to be fully loaded and executed so you don't have to :)
 
-<details><summary><strong>For the sake of simplicity, expand this for the complete list of arguments</strong></summary>
+#### The complete list of arguments
 
 |      Argument       | Description                                                                                                                                                                                                                                                                                                                                                                                                     | Optional |
 |:-------------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
@@ -286,7 +288,6 @@ True
 |    os_randomize     | If enabled, Scrapling will randomize the OS fingerprints used. The default is Scrapling matching the fingerprints with the current OS.                                                                                                                                                                                                                                                                          |    ✔️    |
 | wait_selector_state | The state to wait for the selector given with `wait_selector`. _Default state is `attached`._                                                                                                                                                                                                                                                                                                                   |    ✔️    |
 
-</details>
 
 This list isn't final so expect a lot more additions and flexibility to be added in the next versions!
 
@@ -316,7 +317,7 @@ Using this Fetcher class, you can make requests with:
 
 Add that to a lot of controlling/hiding options as you will see in the arguments list below.
 
-<details><summary><strong>Expand this for the complete list of arguments</strong></summary>
+#### The complete list of arguments
 
 |      Argument       | Description                                                                                                                                                                                                                                                                                                                                                                                                     | Optional |
 |:-------------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------:|
@@ -341,7 +342,6 @@ Add that to a lot of controlling/hiding options as you will see in the arguments
 |   nstbrowser_mode   | Enables NSTBrowser mode, **it have to be used with `cdp_url` argument or it will get completely ignored.**                                                                                                                                                                                                                                                                                                      |    ✔️    |
 |  nstbrowser_config  | The config you want to send with requests to the NSTBrowser. _If left empty, Scrapling defaults to an optimized NSTBrowser's docker browserless config._                                                                                                                                                                                                                                                        |    ✔️    |
 
-</details>
 
 This list isn't final so expect a lot more additions and flexibility to be added in the next versions!
 
@@ -500,7 +500,7 @@ The selector will no longer function and your code needs maintenance. That's whe
 ```python
 from scrapling.parser import Adaptor
 # Before the change
-page = Adaptor(page_source, url='example.com')
+page = Adaptor(page_source, auto_match=True, url='example.com')
 element = page.css('#p1' auto_save=True)
 if not element:  # One day website changes?
     element = page.css('#p1', auto_match=True)  # Scrapling still finds it!
@@ -520,12 +520,13 @@ Now let's test the same selector in both versions
 >> selector = '#hmenus > div:nth-child(1) > ul > li:nth-child(1) > a'
 >> old_url = "https://web.archive.org/web/20100102003420/http://stackoverflow.com/"
 >> new_url = "https://stackoverflow.com/"
+>> Fetcher.configure(auto_match=True, automatch_domain='stackoverflow.com')
 >> 
->> page = Fetcher(automatch_domain='stackoverflow.com').get(old_url, timeout=30)
+>> page = Fetcher.get(old_url, timeout=30)
 >> element1 = page.css_first(selector, auto_save=True)
 >> 
 >> # Same selector but used in the updated website
->> page = Fetcher(automatch_domain="stackoverflow.com").get(new_url)
+>> page = Fetcher.get(new_url)
 >> element2 = page.css_first(selector, auto_match=True)
 >> 
 >> if element1.text == element2.text:

--- a/README.md
+++ b/README.md
@@ -217,11 +217,17 @@ or
 ```
 Then continue your code as normal.
 
-The available configuration arguments are: `auto_match`, `huge_tree`, `keep_comments`, `keep_cdata`, `storage`, and `storage_args`, which are the same ones you give to the `Adaptor` class.
+The available configuration arguments are: `auto_match`, `huge_tree`, `keep_comments`, `keep_cdata`, `storage`, and `storage_args`, which are the same ones you give to the `Adaptor` class. You can display the current configuration anytime by running `<fetcher_class>.display_config()`
 
 Also, the `Response` object returned from all fetchers is the same as the `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, `history`, and `request_headers`. All `cookies`, `headers`, and `request_headers` are always of type `dictionary`.
 > [!NOTE]
 > The `auto_match` argument is enabled by default which is the one you should care about the most as you will see later.
+
+#### Set parser config per request
+As you probably understood, the logic above for setting the parser config will work globally for all requests/fetches done through that class and it's intended.
+
+If your use case requires you to use different config for each request/fetch, then you can pass a dictionary to the request method (`fetch`/`get`/`post`/...) to an argument named `custom_config`.
+
 ### Fetcher
 This class is built on top of [httpx](https://www.python-httpx.org/) with additional configuration options, here you can do `GET`, `POST`, `PUT`, and `DELETE` requests.
 

--- a/scrapling/__init__.py
+++ b/scrapling/__init__.py
@@ -1,6 +1,6 @@
 
 __author__ = "Karim Shoair (karim.shoair@pm.me)"
-__version__ = "0.2.98"
+__version__ = "0.2.99"
 __copyright__ = "Copyright (c) 2024 Karim Shoair"
 
 

--- a/scrapling/defaults.py
+++ b/scrapling/defaults.py
@@ -1,19 +1,25 @@
-# If you are going to use Fetchers with the default settings, import them from this file instead for a cleaner looking code
+# Left this file for backward-compatibility before 0.2.99
+from scrapling.core.utils import log
+
 
 # A lightweight approach to create lazy loader for each import for backward compatibility
 # This will reduces initial memory footprint significantly (only loads what's used)
 def __getattr__(name):
     if name == 'Fetcher':
         from scrapling.fetchers import Fetcher as cls
-        return cls()
+        log.warning('This import is deprecated now and it will be removed with v0.3. Use `from scrapling.fetchers import Fetcher` instead')
+        return cls
     elif name == 'AsyncFetcher':
         from scrapling.fetchers import AsyncFetcher as cls
-        return cls()
+        log.warning('This import is deprecated now and it will be removed with v0.3. Use `from scrapling.fetchers import AsyncFetcher` instead')
+        return cls
     elif name == 'StealthyFetcher':
         from scrapling.fetchers import StealthyFetcher as cls
-        return cls()
+        log.warning('This import is deprecated now and it will be removed with v0.3. Use `from scrapling.fetchers import StealthyFetcher` instead')
+        return cls
     elif name == 'PlayWrightFetcher':
         from scrapling.fetchers import PlayWrightFetcher as cls
-        return cls()
+        log.warning('This import is deprecated now and it will be removed with v0.3. Use `from scrapling.fetchers import PlayWrightFetcher` instead')
+        return cls
     else:
         raise AttributeError(f"module 'scrapling' has no attribute '{name}'")

--- a/scrapling/engines/camo.py
+++ b/scrapling/engines/camo.py
@@ -22,6 +22,7 @@ class CamoufoxEngine:
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False,
             geoip: bool = False,
             adaptor_arguments: Dict = None,
+            **additional_arguments: Dict
     ):
         """An engine that utilizes Camoufox library, check the `StealthyFetcher` class for more documentation.
 
@@ -48,6 +49,7 @@ class CamoufoxEngine:
         :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         :param adaptor_arguments: The arguments that will be passed in the end while creating the final Adaptor's class.
+        :param additional_arguments: Any Additional arguments will be passed to Camoufox as additional settings and takes higher priority than Scrapling's settings.
         """
         self.headless = headless
         self.block_images = bool(block_images)
@@ -60,6 +62,7 @@ class CamoufoxEngine:
         self.disable_ads = bool(disable_ads)
         self.geoip = bool(geoip)
         self.extra_headers = extra_headers or {}
+        self.additional_arguments = additional_arguments
         self.proxy = construct_proxy_dict(proxy)
         self.addons = addons or []
         self.humanize = humanize
@@ -92,6 +95,7 @@ class CamoufoxEngine:
             "block_webrtc": self.block_webrtc,
             "block_images": self.block_images,  # Careful! it makes some websites doesn't finish loading at all like stackoverflow even in headful
             "os": None if self.os_randomize else get_os_name(),
+            **self.additional_arguments
         }
 
     def _process_response_history(self, first_response):

--- a/scrapling/engines/camo.py
+++ b/scrapling/engines/camo.py
@@ -22,7 +22,7 @@ class CamoufoxEngine:
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False,
             geoip: bool = False,
             adaptor_arguments: Dict = None,
-            **additional_arguments: Dict
+            additional_arguments: Dict = None
     ):
         """An engine that utilizes Camoufox library, check the `StealthyFetcher` class for more documentation.
 
@@ -49,7 +49,7 @@ class CamoufoxEngine:
         :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         :param adaptor_arguments: The arguments that will be passed in the end while creating the final Adaptor's class.
-        :param additional_arguments: Any Additional arguments will be passed to Camoufox as additional settings and takes higher priority than Scrapling's settings.
+        :param additional_arguments: Additional arguments to be passed to Camoufox as additional settings and it takes higher priority than Scrapling's settings.
         """
         self.headless = headless
         self.block_images = bool(block_images)
@@ -62,7 +62,7 @@ class CamoufoxEngine:
         self.disable_ads = bool(disable_ads)
         self.geoip = bool(geoip)
         self.extra_headers = extra_headers or {}
-        self.additional_arguments = additional_arguments
+        self.additional_arguments = additional_arguments or {}
         self.proxy = construct_proxy_dict(proxy)
         self.addons = addons or []
         self.humanize = humanize

--- a/scrapling/engines/camo.py
+++ b/scrapling/engines/camo.py
@@ -16,7 +16,7 @@ from scrapling.engines.toolbelt import (Response, StatusText,
 class CamoufoxEngine:
     def __init__(
             self, headless: Union[bool, Literal['virtual']] = True, block_images: bool = False, disable_resources: bool = False,
-            block_webrtc: bool = False, allow_webgl: bool = True, network_idle: bool = False, humanize: Union[bool, float] = True,
+            block_webrtc: bool = False, allow_webgl: bool = True, network_idle: bool = False, humanize: Union[bool, float] = True, wait: Optional[int] = 0,
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, addons: Optional[List[str]] = None,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False,
@@ -39,6 +39,7 @@ class CamoufoxEngine:
         :param network_idle: Wait for the page until there are no network connections for at least 500 ms.
         :param disable_ads: Disabled by default, this installs `uBlock Origin` addon on the browser if enabled.
         :param os_randomize: If enabled, Scrapling will randomize the OS fingerprints used. The default is Scrapling matching the fingerprints with the current OS.
+        :param wait: The time (milliseconds) the fetcher will wait after everything finishes before closing the page and returning `Response` object.
         :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000
         :param page_action: Added for automation. A function that takes the `page` object, does the automation you need, then returns `page` again.
         :param wait_selector: Wait for a specific css selector to be in a specific state.
@@ -67,6 +68,7 @@ class CamoufoxEngine:
         self.addons = addons or []
         self.humanize = humanize
         self.timeout = check_type_validity(timeout, [int, float], 30000)
+        self.wait = check_type_validity(wait, [int, float], 0)
 
         # Page action callable validation
         self.page_action = None
@@ -213,6 +215,7 @@ class CamoufoxEngine:
                 except Exception as e:
                     log.error(f"Error waiting for selector {self.wait_selector}: {e}")
 
+            page.wait_for_timeout(self.wait)
             # In case we didn't catch a document type somehow
             final_response = final_response if final_response else first_response
             if not final_response:
@@ -299,6 +302,7 @@ class CamoufoxEngine:
                 except Exception as e:
                     log.error(f"Error waiting for selector {self.wait_selector}: {e}")
 
+            await page.wait_for_timeout(self.wait)
             # In case we didn't catch a document type somehow
             final_response = final_response if final_response else first_response
             if not final_response:

--- a/scrapling/engines/camo.py
+++ b/scrapling/engines/camo.py
@@ -130,6 +130,38 @@ class CamoufoxEngine:
 
         return history
 
+    async def _async_process_response_history(self, first_response):
+        """Process response history to build a list of Response objects"""
+        history = []
+        current_request = first_response.request.redirected_from
+
+        try:
+            while current_request:
+                try:
+                    current_response = await current_request.response()
+                    history.insert(0, Response(
+                        url=current_request.url,
+                        # using current_response.text() will trigger "Error: Response.text: Response body is unavailable for redirect responses"
+                        text='',
+                        body=b'',
+                        status=current_response.status if current_response else 301,
+                        reason=(current_response.status_text or StatusText.get(current_response.status)) if current_response else StatusText.get(301),
+                        encoding=current_response.headers.get('content-type', '') or 'utf-8',
+                        cookies={},
+                        headers=await current_response.all_headers() if current_response else {},
+                        request_headers=await current_request.all_headers(),
+                        **self.adaptor_arguments
+                    ))
+                except Exception as e:
+                    log.error(f"Error processing redirect: {e}")
+                    break
+
+                current_request = current_request.redirected_from
+        except Exception as e:
+            log.error(f"Error processing response history: {e}")
+
+        return history
+
     def fetch(self, url: str) -> Response:
         """Opens up the browser and do your request based on your chosen options.
 
@@ -277,7 +309,7 @@ class CamoufoxEngine:
             # PlayWright API sometimes give empty status text for some reason!
             status_text = final_response.status_text or StatusText.get(final_response.status)
 
-            history = self._process_response_history(first_response)
+            history = await self._async_process_response_history(first_response)
             try:
                 page_content = await page.content()
             except Exception as e:

--- a/scrapling/engines/pw.py
+++ b/scrapling/engines/pw.py
@@ -21,6 +21,7 @@ class PlaywrightEngine:
             useragent: Optional[str] = None,
             network_idle: bool = False,
             timeout: Optional[float] = 30000,
+            wait: Optional[int] = 0,
             page_action: Callable = None,
             wait_selector: Optional[str] = None,
             locale: Optional[str] = 'en-US',
@@ -46,6 +47,7 @@ class PlaywrightEngine:
         :param useragent: Pass a useragent string to be used. Otherwise the fetcher will generate a real Useragent of the same browser and use it.
         :param network_idle: Wait for the page until there are no network connections for at least 500 ms.
         :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000
+        :param wait: The time (milliseconds) the fetcher will wait after everything finishes before closing the page and returning `Response` object.
         :param page_action: Added for automation. A function that takes the `page` object, does the automation you need, then returns `page` again.
         :param wait_selector: Wait for a specific css selector to be in a specific state.
         :param locale: Set the locale for the browser if wanted. The default value is `en-US`.
@@ -76,6 +78,7 @@ class PlaywrightEngine:
         self.cdp_url = cdp_url
         self.useragent = useragent
         self.timeout = check_type_validity(timeout, [int, float], 30000)
+        self.wait = check_type_validity(wait, [int, float], 0)
         if page_action is not None:
             if callable(page_action):
                 self.page_action = page_action
@@ -289,6 +292,7 @@ class PlaywrightEngine:
                 except Exception as e:
                     log.error(f"Error waiting for selector {self.wait_selector}: {e}")
 
+            page.wait_for_timeout(self.wait)
             # In case we didn't catch a document type somehow
             final_response = final_response if final_response else first_response
             if not final_response:
@@ -392,6 +396,7 @@ class PlaywrightEngine:
                 except Exception as e:
                     log.error(f"Error waiting for selector {self.wait_selector}: {e}")
 
+            await page.wait_for_timeout(self.wait)
             # In case we didn't catch a document type somehow
             final_response = final_response if final_response else first_response
             if not final_response:

--- a/scrapling/engines/toolbelt/custom.py
+++ b/scrapling/engines/toolbelt/custom.py
@@ -122,7 +122,7 @@ class BaseFetcher:
         if args_str:
             args_str += ', '
 
-        log.warning(f'This logic is deprecated now and it will be removed with v0.3. Use `{self.__class__.__name__}.configure({args_str}{kwargs_str})` instead before fetching')
+        log.warning(f'This logic is deprecated now, and have no effect; It will be removed with v0.3. Use `{self.__class__.__name__}.configure({args_str}{kwargs_str})` instead before fetching')
         pass
 
     @classmethod
@@ -139,7 +139,7 @@ class BaseFetcher:
 
     @classmethod
     def configure(cls, **kwargs):
-        """Setup multiple arguments for the parser at once
+        """Set multiple arguments for the parser at once globally
 
         :param kwargs: The keywords can be any arguments of the following: huge_tree, keep_comments, keep_cdata, auto_match, storage, storage_args, automatch_domain
         """

--- a/scrapling/engines/toolbelt/custom.py
+++ b/scrapling/engines/toolbelt/custom.py
@@ -105,41 +105,77 @@ class Response(Adaptor):
 
 
 class BaseFetcher:
-    def __init__(
-            self, huge_tree: bool = True, keep_comments: Optional[bool] = False, auto_match: Optional[bool] = True,
-            storage: Any = SQLiteStorageSystem, storage_args: Optional[Dict] = None,
-            automatch_domain: Optional[str] = None, keep_cdata: Optional[bool] = False,
-    ):
-        """Arguments below are the same from the Adaptor class so you can pass them directly, the rest of Adaptor's arguments
-        are detected and passed automatically from the Fetcher based on the response for accessibility.
+    __slots__ = ()
+    huge_tree: bool = True
+    auto_match: Optional[bool] = True
+    storage: Any = SQLiteStorageSystem
+    keep_cdata: Optional[bool] = False
+    storage_args: Optional[Dict] = None
+    keep_comments: Optional[bool] = False
+    automatch_domain: Optional[str] = None
+    parser_keywords: Tuple = ('huge_tree', 'auto_match', 'storage', 'keep_cdata', 'storage_args', 'keep_comments', 'automatch_domain',)  # Left open for the user
 
-        :param huge_tree: Enabled by default, should always be enabled when parsing large HTML documents. This controls
-            libxml2 feature that forbids parsing certain large documents to protect from possible memory exhaustion.
-        :param keep_comments: While parsing the HTML body, drop comments or not. Disabled by default for obvious reasons
-        :param keep_cdata: While parsing the HTML body, drop cdata or not. Disabled by default for cleaner HTML.
-        :param auto_match: Globally turn-off the auto-match feature in all functions, this argument takes higher
-            priority over all auto-match related arguments/functions in the class.
-        :param storage: The storage class to be passed for auto-matching functionalities, see ``Docs`` for more info.
-        :param storage_args: A dictionary of ``argument->value`` pairs to be passed for the storage class.
-            If empty, default values will be used.
-        :param automatch_domain: For cases where you want to automatch selectors across different websites as if they were on the same website, use this argument to unify them.
-            Otherwise, the domain of the request is used by default.
+    def __init__(self, *args, **kwargs):
+        # For backward-compatibility before 0.2.99
+        args_str = ", ".join(args) or ''
+        kwargs_str = ", ".join(f'{k}={v}' for k, v in kwargs.items()) or ''
+        if args_str:
+            args_str += ', '
+
+        log.warning(f'This logic is deprecated now and it will be removed with v0.3. Use `{self.__class__.__name__}.configure({args_str}{kwargs_str})` instead before fetching')
+        pass
+
+    @classmethod
+    def display_config(cls):
+        return dict(
+            huge_tree=cls.huge_tree,
+            keep_comments=cls.keep_comments,
+            keep_cdata=cls.keep_cdata,
+            auto_match=cls.auto_match,
+            storage=cls.storage,
+            storage_args=cls.storage_args,
+            automatch_domain=cls.automatch_domain,
+        )
+
+    @classmethod
+    def configure(cls, **kwargs):
+        """Setup multiple arguments for the parser at once
+
+        :param kwargs: The keywords can be any arguments of the following: huge_tree, keep_comments, keep_cdata, auto_match, storage, storage_args, automatch_domain
         """
+        for key, value in kwargs.items():
+            key = key.strip().lower()
+            if hasattr(cls, key):
+                if key in cls.parser_keywords:
+                    setattr(cls, key, value)
+                else:
+                    # Yup, no fun allowed LOL
+                    raise AttributeError(f'Unknown parser argument: "{key}"; maybe you meant {cls.parser_keywords}?')
+            else:
+                raise ValueError(f'Unknown parser argument: "{key}"; maybe you meant {cls.parser_keywords}?')
+
+        if not kwargs:
+            raise AttributeError(f'You must pass a keyword to configure, current keywords: {cls.parser_keywords}?')
+
+    @classmethod
+    def _generate_parser_arguments(cls) -> Dict:
         # Adaptor class parameters
         # I won't validate Adaptor's class parameters here again, I will leave it to be validated later
-        self.adaptor_arguments = dict(
-            huge_tree=huge_tree,
-            keep_comments=keep_comments,
-            keep_cdata=keep_cdata,
-            auto_match=auto_match,
-            storage=storage,
-            storage_args=storage_args
+        parser_arguments = dict(
+            huge_tree=cls.huge_tree,
+            keep_comments=cls.keep_comments,
+            keep_cdata=cls.keep_cdata,
+            auto_match=cls.auto_match,
+            storage=cls.storage,
+            storage_args=cls.storage_args
         )
-        if automatch_domain:
-            if type(automatch_domain) is not str:
+        if cls.automatch_domain:
+            if type(cls.automatch_domain) is not str:
                 log.warning('[Ignored] The argument "automatch_domain" must be of string type')
             else:
-                self.adaptor_arguments.update({'automatch_domain': automatch_domain})
+                parser_arguments.update({'automatch_domain': cls.automatch_domain})
+
+        return parser_arguments
 
 
 class StatusText:

--- a/scrapling/engines/toolbelt/custom.py
+++ b/scrapling/engines/toolbelt/custom.py
@@ -107,7 +107,7 @@ class Response(Adaptor):
 class BaseFetcher:
     __slots__ = ()
     huge_tree: bool = True
-    auto_match: Optional[bool] = True
+    auto_match: Optional[bool] = False
     storage: Any = SQLiteStorageSystem
     keep_cdata: Optional[bool] = False
     storage_args: Optional[Dict] = None

--- a/scrapling/fetchers.py
+++ b/scrapling/fetchers.py
@@ -235,7 +235,7 @@ class StealthyFetcher(BaseFetcher):
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False, geoip: bool = False,
-            custom_config: Dict = None, **additional_arguments: Dict
+            custom_config: Dict = None, additional_arguments: Dict = None
     ) -> Response:
         """
         Opens up a browser and do your request based on your chosen options below.
@@ -264,7 +264,7 @@ class StealthyFetcher(BaseFetcher):
         :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
-        :param additional_arguments: Any Additional arguments will be passed to Camoufox as additional settings and takes higher priority than Scrapling's settings.
+        :param additional_arguments: Additional arguments to be passed to Camoufox as additional settings and it takes higher priority than Scrapling's settings.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
         if not custom_config:
@@ -292,7 +292,7 @@ class StealthyFetcher(BaseFetcher):
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
             adaptor_arguments={**cls._generate_parser_arguments(), **custom_config},
-            **additional_arguments
+            additional_arguments=additional_arguments or {}
         )
         return engine.fetch(url)
 
@@ -303,7 +303,7 @@ class StealthyFetcher(BaseFetcher):
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False, geoip: bool = False,
-            custom_config: Dict = None, **additional_arguments: Dict
+            custom_config: Dict = None, additional_arguments: Dict = None
     ) -> Response:
         """
         Opens up a browser and do your request based on your chosen options below.
@@ -332,7 +332,7 @@ class StealthyFetcher(BaseFetcher):
         :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
-        :param additional_arguments: Any Additional arguments will be passed to Camoufox as additional settings and takes higher priority than Scrapling's settings.
+        :param additional_arguments: Additional arguments to be passed to Camoufox as additional settings and it takes higher priority than Scrapling's settings.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
         if not custom_config:
@@ -360,7 +360,7 @@ class StealthyFetcher(BaseFetcher):
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
             adaptor_arguments={**cls._generate_parser_arguments(), **custom_config},
-            **additional_arguments
+            additional_arguments=additional_arguments or {}
         )
         return await engine.async_fetch(url)
 

--- a/scrapling/fetchers.py
+++ b/scrapling/fetchers.py
@@ -10,8 +10,9 @@ class Fetcher(BaseFetcher):
 
     Any additional keyword arguments passed to the methods below are passed to the respective httpx's method directly.
     """
+    @classmethod
     def get(
-            self, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
+            cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
             proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
         """Make basic HTTP GET request for you but with some added flavors.
 
@@ -25,12 +26,13 @@ class Fetcher(BaseFetcher):
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.get()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(self.adaptor_arguments.items())
+        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
         response_object = StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries, adaptor_arguments=adaptor_arguments).get(**kwargs)
         return response_object
 
+    @classmethod
     def post(
-            self, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
+            cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
             proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
         """Make basic HTTP POST request for you but with some added flavors.
 
@@ -44,12 +46,13 @@ class Fetcher(BaseFetcher):
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.post()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(self.adaptor_arguments.items())
+        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
         response_object = StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries, adaptor_arguments=adaptor_arguments).post(**kwargs)
         return response_object
 
+    @classmethod
     def put(
-            self, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
+            cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
             proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
         """Make basic HTTP PUT request for you but with some added flavors.
 
@@ -64,12 +67,13 @@ class Fetcher(BaseFetcher):
 
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(self.adaptor_arguments.items())
+        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
         response_object = StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries, adaptor_arguments=adaptor_arguments).put(**kwargs)
         return response_object
 
+    @classmethod
     def delete(
-            self, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
+            cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
             proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
         """Make basic HTTP DELETE request for you but with some added flavors.
 
@@ -83,14 +87,15 @@ class Fetcher(BaseFetcher):
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.delete()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(self.adaptor_arguments.items())
+        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
         response_object = StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries, adaptor_arguments=adaptor_arguments).delete(**kwargs)
         return response_object
 
 
 class AsyncFetcher(Fetcher):
+    @classmethod
     async def get(
-            self, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
+            cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
             proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
         """Make basic HTTP GET request for you but with some added flavors.
 
@@ -104,12 +109,13 @@ class AsyncFetcher(Fetcher):
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.get()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(self.adaptor_arguments.items())
+        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
         response_object = await StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries=retries, adaptor_arguments=adaptor_arguments).async_get(**kwargs)
         return response_object
 
+    @classmethod
     async def post(
-            self, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
+            cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
             proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
         """Make basic HTTP POST request for you but with some added flavors.
 
@@ -123,12 +129,13 @@ class AsyncFetcher(Fetcher):
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.post()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(self.adaptor_arguments.items())
+        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
         response_object = await StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries=retries, adaptor_arguments=adaptor_arguments).async_post(**kwargs)
         return response_object
 
+    @classmethod
     async def put(
-            self, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
+            cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
             proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
         """Make basic HTTP PUT request for you but with some added flavors.
 
@@ -142,12 +149,13 @@ class AsyncFetcher(Fetcher):
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.put()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(self.adaptor_arguments.items())
+        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
         response_object = await StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries=retries, adaptor_arguments=adaptor_arguments).async_put(**kwargs)
         return response_object
 
+    @classmethod
     async def delete(
-            self, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
+            cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
             proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
         """Make basic HTTP DELETE request for you but with some added flavors.
 
@@ -161,7 +169,7 @@ class AsyncFetcher(Fetcher):
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.delete()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(self.adaptor_arguments.items())
+        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
         response_object = await StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries=retries, adaptor_arguments=adaptor_arguments).async_delete(**kwargs)
         return response_object
 
@@ -172,8 +180,9 @@ class StealthyFetcher(BaseFetcher):
      It works as real browsers passing almost all online tests/protections based on Camoufox.
      Other added flavors include setting the faked OS fingerprints to match the user's OS and the referer of every request is set as if this request came from Google's search of this URL's domain.
     """
+    @classmethod
     def fetch(
-            self, url: str, headless: Union[bool, Literal['virtual']] = True, block_images: bool = False, disable_resources: bool = False,
+            cls, url: str, headless: Union[bool, Literal['virtual']] = True, block_images: bool = False, disable_resources: bool = False,
             block_webrtc: bool = False, allow_webgl: bool = True, network_idle: bool = False, addons: Optional[List[str]] = None,
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
@@ -226,12 +235,13 @@ class StealthyFetcher(BaseFetcher):
             extra_headers=extra_headers,
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
-            adaptor_arguments=self.adaptor_arguments,
+            adaptor_arguments=cls._generate_parser_arguments(),
         )
         return engine.fetch(url)
 
+    @classmethod
     async def async_fetch(
-            self, url: str, headless: Union[bool, Literal['virtual']] = True, block_images: bool = False, disable_resources: bool = False,
+            cls, url: str, headless: Union[bool, Literal['virtual']] = True, block_images: bool = False, disable_resources: bool = False,
             block_webrtc: bool = False, allow_webgl: bool = True, network_idle: bool = False, addons: Optional[List[str]] = None,
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
@@ -284,7 +294,7 @@ class StealthyFetcher(BaseFetcher):
             extra_headers=extra_headers,
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
-            adaptor_arguments=self.adaptor_arguments,
+            adaptor_arguments=cls._generate_parser_arguments(),
         )
         return await engine.async_fetch(url)
 
@@ -305,8 +315,9 @@ class PlayWrightFetcher(BaseFetcher):
 
     > Note that these are the main options with PlayWright but it can be mixed together.
     """
+    @classmethod
     def fetch(
-            self, url: str, headless: Union[bool, str] = True, disable_resources: bool = None,
+            cls, url: str, headless: Union[bool, str] = True, disable_resources: bool = None,
             useragent: Optional[str] = None, network_idle: bool = False, timeout: Optional[float] = 30000,
             page_action: Optional[Callable] = None, wait_selector: Optional[str] = None, wait_selector_state: SelectorWaitStates = 'attached',
             hide_canvas: bool = False, disable_webgl: bool = False, extra_headers: Optional[Dict[str, str]] = None, google_search: bool = True,
@@ -361,12 +372,13 @@ class PlayWrightFetcher(BaseFetcher):
             nstbrowser_config=nstbrowser_config,
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
-            adaptor_arguments=self.adaptor_arguments,
+            adaptor_arguments=cls._generate_parser_arguments(),
         )
         return engine.fetch(url)
 
+    @classmethod
     async def async_fetch(
-            self, url: str, headless: Union[bool, str] = True, disable_resources: bool = None,
+            cls, url: str, headless: Union[bool, str] = True, disable_resources: bool = None,
             useragent: Optional[str] = None, network_idle: bool = False, timeout: Optional[float] = 30000,
             page_action: Optional[Callable] = None, wait_selector: Optional[str] = None, wait_selector_state: SelectorWaitStates = 'attached',
             hide_canvas: bool = False, disable_webgl: bool = False, extra_headers: Optional[Dict[str, str]] = None, google_search: bool = True,
@@ -421,12 +433,13 @@ class PlayWrightFetcher(BaseFetcher):
             nstbrowser_config=nstbrowser_config,
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
-            adaptor_arguments=self.adaptor_arguments,
+            adaptor_arguments=cls._generate_parser_arguments(),
         )
         return await engine.async_fetch(url)
 
 
 class CustomFetcher(BaseFetcher):
-    def fetch(self, url: str, browser_engine, **kwargs) -> Response:
-        engine = check_if_engine_usable(browser_engine)(adaptor_arguments=self.adaptor_arguments, **kwargs)
+    @classmethod
+    def fetch(cls, url: str, browser_engine, **kwargs) -> Response:
+        engine = check_if_engine_usable(browser_engine)(adaptor_arguments=cls._generate_parser_arguments(), **kwargs)
         return engine.fetch(url)

--- a/scrapling/fetchers.py
+++ b/scrapling/fetchers.py
@@ -384,7 +384,7 @@ class PlayWrightFetcher(BaseFetcher):
     @classmethod
     def fetch(
             cls, url: str, headless: Union[bool, str] = True, disable_resources: bool = None,
-            useragent: Optional[str] = None, network_idle: bool = False, timeout: Optional[float] = 30000,
+            useragent: Optional[str] = None, network_idle: bool = False, timeout: Optional[float] = 30000, wait: Optional[int] = 0,
             page_action: Optional[Callable] = None, wait_selector: Optional[str] = None, wait_selector_state: SelectorWaitStates = 'attached',
             hide_canvas: bool = False, disable_webgl: bool = False, extra_headers: Optional[Dict[str, str]] = None, google_search: bool = True,
             proxy: Optional[Union[str, Dict[str, str]]] = None, locale: Optional[str] = 'en-US',
@@ -402,7 +402,8 @@ class PlayWrightFetcher(BaseFetcher):
             This can help save your proxy usage but be careful with this option as it makes some websites never finish loading.
         :param useragent: Pass a useragent string to be used. Otherwise the fetcher will generate a real Useragent of the same browser and use it.
         :param network_idle: Wait for the page until there are no network connections for at least 500 ms.
-        :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000
+        :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000.
+        :param wait: The time (milliseconds) the fetcher will wait after everything finishes before closing the page and returning `Response` object.
         :param locale: Set the locale for the browser if wanted. The default value is `en-US`.
         :param page_action: Added for automation. A function that takes the `page` object, does the automation you need, then returns `page` again.
         :param wait_selector: Wait for a specific css selector to be in a specific state.
@@ -426,6 +427,7 @@ class PlayWrightFetcher(BaseFetcher):
             ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
 
         engine = PlaywrightEngine(
+            wait=wait,
             proxy=proxy,
             locale=locale,
             timeout=timeout,
@@ -452,7 +454,7 @@ class PlayWrightFetcher(BaseFetcher):
     @classmethod
     async def async_fetch(
             cls, url: str, headless: Union[bool, str] = True, disable_resources: bool = None,
-            useragent: Optional[str] = None, network_idle: bool = False, timeout: Optional[float] = 30000,
+            useragent: Optional[str] = None, network_idle: bool = False, timeout: Optional[float] = 30000, wait: Optional[int] = 0,
             page_action: Optional[Callable] = None, wait_selector: Optional[str] = None, wait_selector_state: SelectorWaitStates = 'attached',
             hide_canvas: bool = False, disable_webgl: bool = False, extra_headers: Optional[Dict[str, str]] = None, google_search: bool = True,
             proxy: Optional[Union[str, Dict[str, str]]] = None, locale: Optional[str] = 'en-US',
@@ -470,7 +472,8 @@ class PlayWrightFetcher(BaseFetcher):
             This can help save your proxy usage but be careful with this option as it makes some websites never finish loading.
         :param useragent: Pass a useragent string to be used. Otherwise the fetcher will generate a real Useragent of the same browser and use it.
         :param network_idle: Wait for the page until there are no network connections for at least 500 ms.
-        :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000
+        :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000.
+        :param wait: The time (milliseconds) the fetcher will wait after everything finishes before closing the page and returning `Response` object.
         :param locale: Set the locale for the browser if wanted. The default value is `en-US`.
         :param page_action: Added for automation. A function that takes the `page` object, does the automation you need, then returns `page` again.
         :param wait_selector: Wait for a specific css selector to be in a specific state.
@@ -494,6 +497,7 @@ class PlayWrightFetcher(BaseFetcher):
             ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
 
         engine = PlaywrightEngine(
+            wait=wait,
             proxy=proxy,
             locale=locale,
             timeout=timeout,

--- a/scrapling/fetchers.py
+++ b/scrapling/fetchers.py
@@ -235,7 +235,7 @@ class StealthyFetcher(BaseFetcher):
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False, geoip: bool = False,
-            custom_config: Dict = None
+            custom_config: Dict = None, **additional_arguments: Dict
     ) -> Response:
         """
         Opens up a browser and do your request based on your chosen options below.
@@ -264,6 +264,7 @@ class StealthyFetcher(BaseFetcher):
         :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
+        :param additional_arguments: Any Additional arguments will be passed to Camoufox as additional settings and takes higher priority than Scrapling's settings.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
         if not custom_config:
@@ -291,6 +292,7 @@ class StealthyFetcher(BaseFetcher):
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
             adaptor_arguments={**cls._generate_parser_arguments(), **custom_config},
+            **additional_arguments
         )
         return engine.fetch(url)
 
@@ -301,7 +303,7 @@ class StealthyFetcher(BaseFetcher):
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False, geoip: bool = False,
-            custom_config: Dict = None
+            custom_config: Dict = None, **additional_arguments: Dict
     ) -> Response:
         """
         Opens up a browser and do your request based on your chosen options below.
@@ -330,6 +332,7 @@ class StealthyFetcher(BaseFetcher):
         :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
+        :param additional_arguments: Any Additional arguments will be passed to Camoufox as additional settings and takes higher priority than Scrapling's settings.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
         if not custom_config:
@@ -357,6 +360,7 @@ class StealthyFetcher(BaseFetcher):
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
             adaptor_arguments={**cls._generate_parser_arguments(), **custom_config},
+            **additional_arguments
         )
         return await engine.async_fetch(url)
 

--- a/scrapling/fetchers.py
+++ b/scrapling/fetchers.py
@@ -13,7 +13,7 @@ class Fetcher(BaseFetcher):
     @classmethod
     def get(
             cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
-            proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
+            proxy: Optional[str] = None, retries: Optional[int] = 3, custom_config: Dict = None, **kwargs: Dict) -> Response:
         """Make basic HTTP GET request for you but with some added flavors.
 
         :param url: Target url.
@@ -23,17 +23,23 @@ class Fetcher(BaseFetcher):
             create a referer header as if this request had came from Google's search of this URL's domain.
         :param proxy: A string of a proxy to use for http and https requests, the format accepted is `http://username:password@localhost:8030`
         :param retries: The number of retries to do through httpx if the request failed for any reason. The default is 3 retries.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.get()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
+        adaptor_arguments = tuple({**cls._generate_parser_arguments(), **custom_config}.items())
         response_object = StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries, adaptor_arguments=adaptor_arguments).get(**kwargs)
         return response_object
 
     @classmethod
     def post(
             cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
-            proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
+            proxy: Optional[str] = None, retries: Optional[int] = 3, custom_config: Dict = None, **kwargs: Dict) -> Response:
         """Make basic HTTP POST request for you but with some added flavors.
 
         :param url: Target url.
@@ -43,17 +49,23 @@ class Fetcher(BaseFetcher):
             create a referer header as if this request came from Google's search of this URL's domain.
         :param proxy: A string of a proxy to use for http and https requests, the format accepted is `http://username:password@localhost:8030`
         :param retries: The number of retries to do through httpx if the request failed for any reason. The default is 3 retries.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.post()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
+        adaptor_arguments = tuple({**cls._generate_parser_arguments(), **custom_config}.items())
         response_object = StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries, adaptor_arguments=adaptor_arguments).post(**kwargs)
         return response_object
 
     @classmethod
     def put(
             cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
-            proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
+            proxy: Optional[str] = None, retries: Optional[int] = 3, custom_config: Dict = None, **kwargs: Dict) -> Response:
         """Make basic HTTP PUT request for you but with some added flavors.
 
         :param url: Target url
@@ -63,18 +75,24 @@ class Fetcher(BaseFetcher):
             create a referer header as if this request came from Google's search of this URL's domain.
         :param proxy: A string of a proxy to use for http and https requests, the format accepted is `http://username:password@localhost:8030`
         :param retries: The number of retries to do through httpx if the request failed for any reason. The default is 3 retries.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.put()` function so check httpx documentation for details.
 
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
+        adaptor_arguments = tuple({**cls._generate_parser_arguments(), **custom_config}.items())
         response_object = StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries, adaptor_arguments=adaptor_arguments).put(**kwargs)
         return response_object
 
     @classmethod
     def delete(
             cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
-            proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
+            proxy: Optional[str] = None, retries: Optional[int] = 3, custom_config: Dict = None, **kwargs: Dict) -> Response:
         """Make basic HTTP DELETE request for you but with some added flavors.
 
         :param url: Target url
@@ -84,10 +102,16 @@ class Fetcher(BaseFetcher):
             create a referer header as if this request came from Google's search of this URL's domain.
         :param proxy: A string of a proxy to use for http and https requests, the format accepted is `http://username:password@localhost:8030`
         :param retries: The number of retries to do through httpx if the request failed for any reason. The default is 3 retries.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.delete()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
+        adaptor_arguments = tuple({**cls._generate_parser_arguments(), **custom_config}.items())
         response_object = StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries, adaptor_arguments=adaptor_arguments).delete(**kwargs)
         return response_object
 
@@ -96,7 +120,7 @@ class AsyncFetcher(Fetcher):
     @classmethod
     async def get(
             cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
-            proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
+            proxy: Optional[str] = None, retries: Optional[int] = 3, custom_config: Dict = None, **kwargs: Dict) -> Response:
         """Make basic HTTP GET request for you but with some added flavors.
 
         :param url: Target url.
@@ -106,17 +130,23 @@ class AsyncFetcher(Fetcher):
             create a referer header as if this request had came from Google's search of this URL's domain.
         :param proxy: A string of a proxy to use for http and https requests, the format accepted is `http://username:password@localhost:8030`
         :param retries: The number of retries to do through httpx if the request failed for any reason. The default is 3 retries.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.get()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
+        adaptor_arguments = tuple({**cls._generate_parser_arguments(), **custom_config}.items())
         response_object = await StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries=retries, adaptor_arguments=adaptor_arguments).async_get(**kwargs)
         return response_object
 
     @classmethod
     async def post(
             cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
-            proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
+            proxy: Optional[str] = None, retries: Optional[int] = 3, custom_config: Dict = None, **kwargs: Dict) -> Response:
         """Make basic HTTP POST request for you but with some added flavors.
 
         :param url: Target url.
@@ -126,17 +156,23 @@ class AsyncFetcher(Fetcher):
             create a referer header as if this request came from Google's search of this URL's domain.
         :param proxy: A string of a proxy to use for http and https requests, the format accepted is `http://username:password@localhost:8030`
         :param retries: The number of retries to do through httpx if the request failed for any reason. The default is 3 retries.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.post()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
+        adaptor_arguments = tuple({**cls._generate_parser_arguments(), **custom_config}.items())
         response_object = await StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries=retries, adaptor_arguments=adaptor_arguments).async_post(**kwargs)
         return response_object
 
     @classmethod
     async def put(
             cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
-            proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
+            proxy: Optional[str] = None, retries: Optional[int] = 3, custom_config: Dict = None, **kwargs: Dict) -> Response:
         """Make basic HTTP PUT request for you but with some added flavors.
 
         :param url: Target url
@@ -146,17 +182,23 @@ class AsyncFetcher(Fetcher):
             create a referer header as if this request came from Google's search of this URL's domain.
         :param proxy: A string of a proxy to use for http and https requests, the format accepted is `http://username:password@localhost:8030`
         :param retries: The number of retries to do through httpx if the request failed for any reason. The default is 3 retries.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.put()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
+        adaptor_arguments = tuple({**cls._generate_parser_arguments(), **custom_config}.items())
         response_object = await StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries=retries, adaptor_arguments=adaptor_arguments).async_put(**kwargs)
         return response_object
 
     @classmethod
     async def delete(
             cls, url: str, follow_redirects: bool = True, timeout: Optional[Union[int, float]] = 10, stealthy_headers: bool = True,
-            proxy: Optional[str] = None, retries: Optional[int] = 3, **kwargs: Dict) -> Response:
+            proxy: Optional[str] = None, retries: Optional[int] = 3, custom_config: Dict = None, **kwargs: Dict) -> Response:
         """Make basic HTTP DELETE request for you but with some added flavors.
 
         :param url: Target url
@@ -166,10 +208,16 @@ class AsyncFetcher(Fetcher):
             create a referer header as if this request came from Google's search of this URL's domain.
         :param proxy: A string of a proxy to use for http and https requests, the format accepted is `http://username:password@localhost:8030`
         :param retries: The number of retries to do through httpx if the request failed for any reason. The default is 3 retries.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :param kwargs: Any additional keyword arguments are passed directly to `httpx.delete()` function so check httpx documentation for details.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
-        adaptor_arguments = tuple(cls._generate_parser_arguments().items())
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
+        adaptor_arguments = tuple({**cls._generate_parser_arguments(), **custom_config}.items())
         response_object = await StaticEngine(url, proxy, stealthy_headers, follow_redirects, timeout, retries=retries, adaptor_arguments=adaptor_arguments).async_delete(**kwargs)
         return response_object
 
@@ -187,6 +235,7 @@ class StealthyFetcher(BaseFetcher):
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False, geoip: bool = False,
+            custom_config: Dict = None
     ) -> Response:
         """
         Opens up a browser and do your request based on your chosen options below.
@@ -214,8 +263,14 @@ class StealthyFetcher(BaseFetcher):
         :param google_search: Enabled by default, Scrapling will set the referer header to be as if this request came from a Google search for this website's domain name.
         :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
         engine = CamoufoxEngine(
             proxy=proxy,
             geoip=geoip,
@@ -235,7 +290,7 @@ class StealthyFetcher(BaseFetcher):
             extra_headers=extra_headers,
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
-            adaptor_arguments=cls._generate_parser_arguments(),
+            adaptor_arguments={**cls._generate_parser_arguments(), **custom_config},
         )
         return engine.fetch(url)
 
@@ -246,6 +301,7 @@ class StealthyFetcher(BaseFetcher):
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False, geoip: bool = False,
+            custom_config: Dict = None
     ) -> Response:
         """
         Opens up a browser and do your request based on your chosen options below.
@@ -273,8 +329,14 @@ class StealthyFetcher(BaseFetcher):
         :param google_search: Enabled by default, Scrapling will set the referer header to be as if this request came from a Google search for this website's domain name.
         :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
         engine = CamoufoxEngine(
             proxy=proxy,
             geoip=geoip,
@@ -294,7 +356,7 @@ class StealthyFetcher(BaseFetcher):
             extra_headers=extra_headers,
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
-            adaptor_arguments=cls._generate_parser_arguments(),
+            adaptor_arguments={**cls._generate_parser_arguments(), **custom_config},
         )
         return await engine.async_fetch(url)
 
@@ -325,6 +387,7 @@ class PlayWrightFetcher(BaseFetcher):
             stealth: bool = False, real_chrome: bool = False,
             cdp_url: Optional[str] = None,
             nstbrowser_mode: bool = False, nstbrowser_config: Optional[Dict] = None,
+            custom_config: Dict = None
     ) -> Response:
         """Opens up a browser and do your request based on your chosen options below.
 
@@ -350,8 +413,14 @@ class PlayWrightFetcher(BaseFetcher):
         :param cdp_url: Instead of launching a new browser instance, connect to this CDP URL to control real browsers/NSTBrowser through CDP.
         :param nstbrowser_mode: Enables NSTBrowser mode, it have to be used with `cdp_url` argument or it will get completely ignored.
         :param nstbrowser_config: The config you want to send with requests to the NSTBrowser. If left empty, Scrapling defaults to an optimized NSTBrowser's docker browserless config.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
         engine = PlaywrightEngine(
             proxy=proxy,
             locale=locale,
@@ -372,7 +441,7 @@ class PlayWrightFetcher(BaseFetcher):
             nstbrowser_config=nstbrowser_config,
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
-            adaptor_arguments=cls._generate_parser_arguments(),
+            adaptor_arguments={**cls._generate_parser_arguments(), **custom_config},
         )
         return engine.fetch(url)
 
@@ -386,6 +455,7 @@ class PlayWrightFetcher(BaseFetcher):
             stealth: bool = False, real_chrome: bool = False,
             cdp_url: Optional[str] = None,
             nstbrowser_mode: bool = False, nstbrowser_config: Optional[Dict] = None,
+            custom_config: Dict = None
     ) -> Response:
         """Opens up a browser and do your request based on your chosen options below.
 
@@ -411,8 +481,14 @@ class PlayWrightFetcher(BaseFetcher):
         :param cdp_url: Instead of launching a new browser instance, connect to this CDP URL to control real browsers/NSTBrowser through CDP.
         :param nstbrowser_mode: Enables NSTBrowser mode, it have to be used with `cdp_url` argument or it will get completely ignored.
         :param nstbrowser_config: The config you want to send with requests to the NSTBrowser. If left empty, Scrapling defaults to an optimized NSTBrowser's docker browserless config.
+        :param custom_config: A dictionary of custom parser arguments to use with this request. Any argument passed will override any class parameters values.
         :return: A `Response` object that is the same as `Adaptor` object except it has these added attributes: `status`, `reason`, `cookies`, `headers`, and `request_headers`
         """
+        if not custom_config:
+            custom_config = {}
+        elif not isinstance(custom_config, dict):
+            ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
+
         engine = PlaywrightEngine(
             proxy=proxy,
             locale=locale,
@@ -433,7 +509,7 @@ class PlayWrightFetcher(BaseFetcher):
             nstbrowser_config=nstbrowser_config,
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
-            adaptor_arguments=cls._generate_parser_arguments(),
+            adaptor_arguments={**cls._generate_parser_arguments(), **custom_config},
         )
         return await engine.async_fetch(url)
 

--- a/scrapling/fetchers.py
+++ b/scrapling/fetchers.py
@@ -231,7 +231,7 @@ class StealthyFetcher(BaseFetcher):
     @classmethod
     def fetch(
             cls, url: str, headless: Union[bool, Literal['virtual']] = True, block_images: bool = False, disable_resources: bool = False,
-            block_webrtc: bool = False, allow_webgl: bool = True, network_idle: bool = False, addons: Optional[List[str]] = None,
+            block_webrtc: bool = False, allow_webgl: bool = True, network_idle: bool = False, addons: Optional[List[str]] = None, wait: Optional[int] = 0,
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False, geoip: bool = False,
@@ -256,7 +256,8 @@ class StealthyFetcher(BaseFetcher):
             It will also calculate and spoof the browser's language based on the distribution of language speakers in the target region.
         :param network_idle: Wait for the page until there are no network connections for at least 500 ms.
         :param os_randomize: If enabled, Scrapling will randomize the OS fingerprints used. The default is Scrapling matching the fingerprints with the current OS.
-        :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000
+        :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000.
+        :param wait: The time (milliseconds) the fetcher will wait after everything finishes before closing the page and returning `Response` object.
         :param page_action: Added for automation. A function that takes the `page` object, does the automation you need, then returns `page` again.
         :param wait_selector: Wait for a specific css selector to be in a specific state.
         :param wait_selector_state: The state to wait for the selector given with `wait_selector`. Default state is `attached`.
@@ -273,6 +274,7 @@ class StealthyFetcher(BaseFetcher):
             ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
 
         engine = CamoufoxEngine(
+            wait=wait,
             proxy=proxy,
             geoip=geoip,
             addons=addons,
@@ -299,7 +301,7 @@ class StealthyFetcher(BaseFetcher):
     @classmethod
     async def async_fetch(
             cls, url: str, headless: Union[bool, Literal['virtual']] = True, block_images: bool = False, disable_resources: bool = False,
-            block_webrtc: bool = False, allow_webgl: bool = True, network_idle: bool = False, addons: Optional[List[str]] = None,
+            block_webrtc: bool = False, allow_webgl: bool = True, network_idle: bool = False, addons: Optional[List[str]] = None, wait: Optional[int] = 0,
             timeout: Optional[float] = 30000, page_action: Callable = None, wait_selector: Optional[str] = None, humanize: Optional[Union[bool, float]] = True,
             wait_selector_state: SelectorWaitStates = 'attached', google_search: bool = True, extra_headers: Optional[Dict[str, str]] = None,
             proxy: Optional[Union[str, Dict[str, str]]] = None, os_randomize: bool = False, disable_ads: bool = False, geoip: bool = False,
@@ -325,6 +327,7 @@ class StealthyFetcher(BaseFetcher):
         :param network_idle: Wait for the page until there are no network connections for at least 500 ms.
         :param os_randomize: If enabled, Scrapling will randomize the OS fingerprints used. The default is Scrapling matching the fingerprints with the current OS.
         :param timeout: The timeout in milliseconds that is used in all operations and waits through the page. The default is 30000
+        :param wait: The time (milliseconds) the fetcher will wait after everything finishes before closing the page and returning `Response` object.
         :param page_action: Added for automation. A function that takes the `page` object, does the automation you need, then returns `page` again.
         :param wait_selector: Wait for a specific css selector to be in a specific state.
         :param wait_selector_state: The state to wait for the selector given with `wait_selector`. Default state is `attached`.
@@ -341,6 +344,7 @@ class StealthyFetcher(BaseFetcher):
             ValueError(f"The custom parser config must be of type dictionary, got {cls.__class__}")
 
         engine = CamoufoxEngine(
+            wait=wait,
             proxy=proxy,
             geoip=geoip,
             addons=addons,

--- a/scrapling/parser.py
+++ b/scrapling/parser.py
@@ -39,7 +39,7 @@ class Adaptor(SelectorsGeneration):
             root: Optional[html.HtmlElement] = None,
             keep_comments: Optional[bool] = False,
             keep_cdata: Optional[bool] = False,
-            auto_match: Optional[bool] = True,
+            auto_match: Optional[bool] = False,
             storage: Any = SQLiteStorageSystem,
             storage_args: Optional[Dict] = None,
             **kwargs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scrapling
-version = 0.2.98
+version = 0.2.99
 author = Karim Shoair
 author_email = karim.shoair@pm.me
 description = Scrapling is an undetectable, powerful, flexible, high-performance Python library that makes Web Scraping easy again!

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     python_requires=">=3.9",
     url="https://github.com/D4Vinci/Scrapling",
     project_urls={
-        "Documentation": "https://github.com/D4Vinci/Scrapling/tree/main/docs",  # For now
+        "Documentation": "https://scrapling.readthedocs.io/en/latest/",
         "Source": "https://github.com/D4Vinci/Scrapling",
         "Tracker": "https://github.com/D4Vinci/Scrapling/issues",
     }

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="scrapling",
-    version="0.2.98",
+    version="0.2.99",
     description="""Scrapling is an undetectable, powerful, flexible, high-performance Python library that makes Web Scraping easy again! In an internet filled with complications,
     it simplifies web scraping, even when websites' design changes, while providing impressive speed that surpasses almost all alternatives.""",
     long_description=long_description,

--- a/tests/fetchers/async/test_camoufox.py
+++ b/tests/fetchers/async/test_camoufox.py
@@ -3,13 +3,15 @@ import pytest_httpbin
 
 from scrapling import StealthyFetcher
 
+StealthyFetcher.auto_match = True
+
 
 @pytest_httpbin.use_class_based_httpbin
 @pytest.mark.asyncio
 class TestStealthyFetcher:
     @pytest.fixture(scope="class")
     def fetcher(self):
-        return StealthyFetcher(auto_match=False)
+        return StealthyFetcher
 
     @pytest.fixture(scope="class")
     def urls(self, httpbin):

--- a/tests/fetchers/async/test_httpx.py
+++ b/tests/fetchers/async/test_httpx.py
@@ -3,13 +3,15 @@ import pytest_httpbin
 
 from scrapling.fetchers import AsyncFetcher
 
+AsyncFetcher.auto_match = True
+
 
 @pytest_httpbin.use_class_based_httpbin
 @pytest.mark.asyncio
 class TestAsyncFetcher:
     @pytest.fixture(scope="class")
     def fetcher(self):
-        return AsyncFetcher(auto_match=True)
+        return AsyncFetcher
 
     @pytest.fixture(scope="class")
     def urls(self, httpbin):

--- a/tests/fetchers/async/test_playwright.py
+++ b/tests/fetchers/async/test_playwright.py
@@ -3,12 +3,14 @@ import pytest_httpbin
 
 from scrapling import PlayWrightFetcher
 
+PlayWrightFetcher.auto_match = True
+
 
 @pytest_httpbin.use_class_based_httpbin
 class TestPlayWrightFetcherAsync:
     @pytest.fixture
     def fetcher(self):
-        return PlayWrightFetcher(auto_match=False)
+        return PlayWrightFetcher
 
     @pytest.fixture
     def urls(self, httpbin):

--- a/tests/fetchers/sync/test_camoufox.py
+++ b/tests/fetchers/sync/test_camoufox.py
@@ -3,13 +3,15 @@ import pytest_httpbin
 
 from scrapling import StealthyFetcher
 
+StealthyFetcher.auto_match = True
+
 
 @pytest_httpbin.use_class_based_httpbin
 class TestStealthyFetcher:
     @pytest.fixture(scope="class")
     def fetcher(self):
         """Fixture to create a StealthyFetcher instance for the entire test class"""
-        return StealthyFetcher(auto_match=False)
+        return StealthyFetcher
 
     @pytest.fixture(autouse=True)
     def setup_urls(self, httpbin):

--- a/tests/fetchers/sync/test_httpx.py
+++ b/tests/fetchers/sync/test_httpx.py
@@ -3,13 +3,15 @@ import pytest_httpbin
 
 from scrapling import Fetcher
 
+Fetcher.auto_match = True
+
 
 @pytest_httpbin.use_class_based_httpbin
 class TestFetcher:
     @pytest.fixture(scope="class")
     def fetcher(self):
         """Fixture to create a Fetcher instance for the entire test class"""
-        return Fetcher(auto_match=False)
+        return Fetcher
 
     @pytest.fixture(autouse=True)
     def setup_urls(self, httpbin):

--- a/tests/fetchers/sync/test_playwright.py
+++ b/tests/fetchers/sync/test_playwright.py
@@ -3,6 +3,8 @@ import pytest_httpbin
 
 from scrapling import PlayWrightFetcher
 
+PlayWrightFetcher.auto_match = True
+
 
 @pytest_httpbin.use_class_based_httpbin
 class TestPlayWrightFetcher:
@@ -10,7 +12,7 @@ class TestPlayWrightFetcher:
     @pytest.fixture(scope="class")
     def fetcher(self):
         """Fixture to create a StealthyFetcher instance for the entire test class"""
-        return PlayWrightFetcher(auto_match=False)
+        return PlayWrightFetcher
 
     @pytest.fixture(autouse=True)
     def setup_urls(self, httpbin):


### PR DESCRIPTION
**This is an essential update for everyone to fully enjoy Scrapling as it's intended.**

## What's changed
### Unified import logic for fetchers
- Now you can import all fetchers with `from scrapling.fetchers import Fetcher, AsyncFetcher, StealthyFetcher, PlayWrightFetcher`, then use them directly like `page = Fetcher.get(...)` without initialization.<br/> This replaces this old import `from scrapling.defaults import Fetcher, AsyncFetcher, StealthyFetcher, PlayWrightFetcher`.
### Breaking change: automatch is now turned off by default
- Now there's new logic to enable automatch from fetchers or other parsing options. Check out the [documentation page](https://scrapling.readthedocs.io/en/latest/fetching/choosing/#parser-configuration-in-all-fetchers) for details.
>  Old imports and logic are left usable with a warning for backward compatibility.
### New options added to fetchers
- Now, both `StealthyFetcher` and `PlayWrightFetcher` have a new argument while fetching called `wait`, which makes the fetcher wait/sleep for a specific period (milliseconds) before closing the page and returning the response to you.
- Now `StealthyFetcher` methods `fetch` and `async_fetch` have the argument `additional_arguments` to be passed to Camoufox as additional settings, which takes higher priority than Scrapling's settings (#54 )
### Bugs squashed
- Fixed a bug in `async_fetch` in both `StealthyFetcher` and `PlayWrightFetcher` classes, with catching redirections.

**_Thanks for all your support and donations!_**

---

## Big shoutout to our biggest Sponsor: [Scrapeless](https://www.scrapeless.com/en/product/deep-serp-api?utm_source=website&utm_medium=ads&utm_campaign=scraping&utm_term=d4vinci)
<a href="https://www.scrapeless.com/en/product/deep-serp-api?utm_source=website&utm_medium=ads&utm_campaign=scraping&utm_term=d4vinci"><img src="https://raw.githubusercontent.com/D4Vinci/Scrapling/main/images/scrapeless.jpg" height="400" alt="Scrapeless Banner" ></a>