### PR TITLE
Fix persistent_context: True

### DIFF
--- a/scrapling/engines/camo.py
+++ b/scrapling/engines/camo.py
@@ -179,7 +179,11 @@ class CamoufoxEngine:
                 final_response = finished_response
 
         with Camoufox(**self._get_camoufox_options()) as browser:
-            context = browser.new_context()
+            if hasattr(browser, 'new_context'):
+                context = browser.new_context()
+            else:
+                context = browser
+
             page = context.new_page()
             page.set_default_navigation_timeout(self.timeout)
             page.set_default_timeout(self.timeout)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Scrapling!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes a critical bug where using `persistent_context: True` in `additional_arguments` with `StealthyFetcher.fetch()` causes an `AttributeError: 'BrowserContext' object has no attribute 'new_context'`.

**The Problem:**
When `persistent_context: True` is specified, Camoufox calls `launch_persistent_context()` which returns a `BrowserContext` object directly, not a `Browser` object. However, Scrapling's camo.py engine assumes it receives a `Browser` object and tries to call `browser.new_context()` on line 182.

**The Solution:**
Added a simple type check to detect when a `BrowserContext` is returned (indicating persistent context is being used) and handle it appropriately by using the context directly instead of trying to create a new one.

**Impact:**
This enables users to properly use persistent browser sessions for:
- Avoiding re-authentication across requests
- Maintaining cookies and session state
- Consistent browser fingerprinting
- Better success rates with anti-bot protection

### Type of change:
<!--
  What type of change does your PR introduce to Scrapling?
  NOTE: Please, check at least 1 box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #64
- This PR is related to issue: 
- Link to documentation pull request: **

**Technical Details:**
- Modified `scrapling/engines/camo.py` around line 182
- Added `hasattr(browser, 'new_context')` check to differentiate between `Browser` and `BrowserContext` objects
- No breaking changes - maintains backward compatibility
- Tested with both regular and persistent context scenarios

**Code Changes:**
```python
# Before (line ~182 in camo.py):
context = browser.new_context()

# After:
if hasattr(browser, 'new_context'):
    # Regular Browser object
    context = browser.new_context()
else:
    # Already a BrowserContext from persistent context
    context = browser
```

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings. 