### PR TITLE
fix: avoid base_url false-positive from incomplete lxml stubs

### DIFF
--- a/scrapling/parser.py
+++ b/scrapling/parser.py
@@ -149,7 +149,11 @@ class Selector(SelectorsGeneration):
                 strip_cdata=(not keep_cdata),
             )
             parser = HTMLParser(**_parser_kwargs)
-            self._root = cast(HtmlElement, fromstring(body or "<html/>", parser=parser, base_url=url or ""))
+            # Keep base_url behavior while avoiding false positives from incomplete type stubs.
+            parse_kwargs: Dict[str, Any] = {"parser": parser}
+            if url:
+                parse_kwargs["base_url"] = url
+            self._root = cast(HtmlElement, fromstring(body or "<html/>", **parse_kwargs))
             self._raw_body = content
 
         else:

--- a/tests/parser/test_parser_advanced.py
+++ b/tests/parser/test_parser_advanced.py
@@ -150,6 +150,11 @@ class TestAdvancedSelectors:
         assert page.urljoin("/absolute") == "https://example.com/absolute"
         assert page.urljoin("relative") == "https://example.com/relative"
 
+    def test_root_base_url_is_set(self):
+        """Test parser preserves document base_url from Selector URL."""
+        page = Selector("<html></html>", url="https://example.com/page")
+        assert page._root.base_url == "https://example.com/page"
+
     def test_find_operations_edge_cases(self, complex_html):
         """Test edge cases in find operations"""
         page = Selector(complex_html)


### PR DESCRIPTION
## Proposed change
This PR fixes a false-positive issue reported in #147 where some IDE/type-checking environments flag `fromstring(..., base_url=...)` as unsupported, despite valid runtime support in `lxml`.

Changes made:
- Keep `base_url` behavior, but pass parser arguments via `parse_kwargs` (`**kwargs`) before calling `fromstring`.
- Add a regression test to verify that `Selector(..., url=...)` preserves `page._root.base_url`.

### Type of change:
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
- This PR fixes or closes an issue: fixes #147
- This PR is related to an issue: #147
- Link to documentation pull request: **N/A**

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.

### Test evidence
Executed locally:
- `python3 -m pytest tests/parser/test_parser_advanced.py -k "root_base_url_is_set or url_joining" -q`

Result:
- `2 passed, 14 deselected`
