### PR TITLE
fix: resolve MCP schema validation failure in VS Code Copilot

### DIFF
--- a/scrapling/core/ai.py
+++ b/scrapling/core/ai.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 
 from scrapling.core.shell import Convertor
 from scrapling.engines.toolbelt.custom import Response as _ScraplingResponse
-from scrapling.engines.static import ImpersonateType
+from scrapling.engines._browsers._types import ImpersonateType
 from scrapling.fetchers import (
     Fetcher,
     FetcherSession,
@@ -50,17 +50,17 @@ class ScraplingMCPServer:
         extraction_type: extraction_types = "markdown",
         css_selector: Optional[str] = None,
         main_content_only: bool = True,
-        params: Optional[Dict | List | Tuple] = None,
-        headers: Optional[Mapping[str, Optional[str]]] = None,
-        cookies: Optional[Dict[str, str] | list[tuple[str, str]]] = None,
+        params: Optional[Dict[str, str]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        cookies: Optional[Dict[str, str]] = None,
         timeout: Optional[int | float] = 30,
         follow_redirects: bool = True,
         max_redirects: int = 30,
         retries: Optional[int] = 3,
         retry_delay: Optional[int] = 1,
         proxy: Optional[str] = None,
-        proxy_auth: Optional[Tuple[str, str]] = None,
-        auth: Optional[Tuple[str, str]] = None,
+        proxy_auth: Optional[List[str]] = None,
+        auth: Optional[List[str]] = None,
         verify: Optional[bool] = True,
         http3: Optional[bool] = False,
         stealthy_headers: Optional[bool] = True,
@@ -95,12 +95,12 @@ class ScraplingMCPServer:
         """
         page = Fetcher.get(
             url,
-            auth=auth,
+            auth=tuple(auth) if auth else None,
             proxy=proxy,
             http3=http3,
             verify=verify,
             params=params,
-            proxy_auth=proxy_auth,
+            proxy_auth=tuple(proxy_auth) if proxy_auth else None,
             retry_delay=retry_delay,
             stealthy_headers=stealthy_headers,
             impersonate=impersonate,
@@ -123,22 +123,22 @@ class ScraplingMCPServer:
 
     @staticmethod
     async def bulk_get(
-        urls: Tuple[str, ...],
+        urls: List[str],
         impersonate: ImpersonateType = "chrome",
         extraction_type: extraction_types = "markdown",
         css_selector: Optional[str] = None,
         main_content_only: bool = True,
-        params: Optional[Dict | List | Tuple] = None,
-        headers: Optional[Mapping[str, Optional[str]]] = None,
-        cookies: Optional[Dict[str, str] | list[tuple[str, str]]] = None,
+        params: Optional[Dict[str, str]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        cookies: Optional[Dict[str, str]] = None,
         timeout: Optional[int | float] = 30,
         follow_redirects: bool = True,
         max_redirects: int = 30,
         retries: Optional[int] = 3,
         retry_delay: Optional[int] = 1,
         proxy: Optional[str] = None,
-        proxy_auth: Optional[Tuple[str, str]] = None,
-        auth: Optional[Tuple[str, str]] = None,
+        proxy_auth: Optional[List[str]] = None,
+        auth: Optional[List[str]] = None,
         verify: Optional[bool] = True,
         http3: Optional[bool] = False,
         stealthy_headers: Optional[bool] = True,
@@ -147,7 +147,7 @@ class ScraplingMCPServer:
         Note: This is only suitable for low-mid protection levels. For high-protection levels or websites that require JS loading, use the other tools directly.
         Note: If the `css_selector` resolves to more than one element, all the elements will be returned.
 
-        :param urls: A tuple of the URLs to request.
+        :param urls: A list of the URLs to request.
         :param impersonate: Browser version to impersonate its fingerprint. It's using the latest chrome version by default.
         :param extraction_type: The type of content to extract from the page. Defaults to "markdown". Options are:
             - Markdown will convert the page content to Markdown format.
@@ -175,7 +175,7 @@ class ScraplingMCPServer:
             tasks: List[Any] = [
                 session.get(
                     url,
-                    auth=auth,
+                    auth=tuple(auth) if auth else None,
                     proxy=proxy,
                     http3=http3,
                     verify=verify,
@@ -184,7 +184,7 @@ class ScraplingMCPServer:
                     cookies=cookies,
                     timeout=timeout,
                     retries=retries,
-                    proxy_auth=proxy_auth,
+                    proxy_auth=tuple(proxy_auth) if proxy_auth else None,
                     retry_delay=retry_delay,
                     impersonate=impersonate,
                     max_redirects=max_redirects,
@@ -257,7 +257,7 @@ class ScraplingMCPServer:
         :param real_chrome: If you have a Chrome browser installed on your device, enable this, and the Fetcher will launch an instance of your browser and use it.
         :param cdp_url: Instead of launching a new browser instance, connect to this CDP URL to control real browsers through CDP.
         :param google_search: Enabled by default, Scrapling will set the referer header to be as if this request came from a Google search of this website's domain name.
-        :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
+        :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `Google Search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         """
         page = await DynamicFetcher.async_fetch(
@@ -291,7 +291,7 @@ class ScraplingMCPServer:
 
     @staticmethod
     async def bulk_fetch(
-        urls: Tuple[str, ...],
+        urls: List[str],
         extraction_type: extraction_types = "markdown",
         css_selector: Optional[str] = None,
         main_content_only: bool = True,
@@ -316,7 +316,7 @@ class ScraplingMCPServer:
         Note: This is only suitable for low-mid protection levels.
         Note: If the `css_selector` resolves to more than one element, all the elements will be returned.
 
-        :param urls: A tuple of the URLs to request.
+        :param urls: A list of the URLs to request.
         :param extraction_type: The type of content to extract from the page. Defaults to "markdown". Options are:
             - Markdown will convert the page content to Markdown format.
             - HTML will return the raw HTML content of the page.
@@ -339,7 +339,7 @@ class ScraplingMCPServer:
         :param real_chrome: If you have a Chrome browser installed on your device, enable this, and the Fetcher will launch an instance of your browser and use it.
         :param cdp_url: Instead of launching a new browser instance, connect to this CDP URL to control real browsers through CDP.
         :param google_search: Enabled by default, Scrapling will set the referer header to be as if this request came from a Google search of this website's domain name.
-        :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `google_search` argument takes priority over the referer set here if used together._
+        :param extra_headers: A dictionary of extra headers to add to the request. _The referer set by the `Google Search` argument takes priority over the referer set here if used together._
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         """
         async with AsyncDynamicSession(
@@ -475,7 +475,7 @@ class ScraplingMCPServer:
 
     @staticmethod
     async def bulk_stealthy_fetch(
-        urls: Tuple[str, ...],
+        urls: List[str],
         extraction_type: extraction_types = "markdown",
         css_selector: Optional[str] = None,
         main_content_only: bool = True,
@@ -505,7 +505,7 @@ class ScraplingMCPServer:
         Note: This is the only suitable fetcher for high protection levels.
         Note: If the `css_selector` resolves to more than one element, all the elements will be returned.
 
-        :param urls: A tuple of the URLs to request.
+        :param urls: A list of the URLs to request.
         :param extraction_type: The type of content to extract from the page. Defaults to "markdown". Options are:
             - Markdown will convert the page content to Markdown format.
             - HTML will return the raw HTML content of the page.


### PR DESCRIPTION
fix(mcp): update import path for ImpersonateType and adjust type hints in ScraplingMCPServer methods, for VS Code compatibility

<!--
  You are amazing! Thanks for contributing to Scrapling!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue in the additional information section.
-->
When attempting to use the Scrapling MCP server in VS Code via GitHub Copilot, the client rejects several tools (`get`, `bulk_get`, `bulk_fetch`, `bulk_stealthy_fetch`) with the following error: `Failed to validate tool mcp_scraplingserv_bulk_get: Error: tool parameters array type must have items.`

VS Code's MCP client uses a very strict JSON Schema validator that demands the `"items"` keyword for any parameter of `type: "array"`. In `core/ai.py`, several parameters used `Tuple` type hints (e.g., `urls: Tuple[str, ...]`, `proxy_auth: Optional[Tuple[str, str]]`). FastMCP/Pydantic translates these Tuples into modern JSON Schema (Draft 2020-12) using the `"prefixItems"` keyword instead of `"items"`. While technically valid modern JSON Schema, VS Code strictly rejects it.

This PR replaces the `Tuple` type hints with `List` (and basic `Dict` for kwargs) type hints in the MCP tool signatures inside `core/ai.py`. This forces Pydantic to generate standard arrays with the `"items"` keyword, which completely resolves the VS Code integration failure without changing the underlying fetching functionality. (The list inputs for `auth` and `proxy_auth` are safely cast back to tuples inside the function calls).

### Type of change:
<!--
  What type of change does your PR introduce to Scrapling?
  NOTE: Please, check at least 1 box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->



- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes an issue: fixes #150 
- This PR is related to an issue: #150 
- Link to documentation pull request: **

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.
