### PR TITLE
Fix typos

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -149,7 +149,7 @@ target_element.find_similar()
 Find the first element that matches a CSS selector
 ```python
 page.css('.product-list [data-id="1"]')[0]
-# <data='<article class="product" data-id="1"><h3...' parent='<div class="product-list"> <article clas...'>
+# <data='<article class="product" data-id="1"><h3...' parent='<div class="product-list"> <article class...'>
 ```
 Find all elements that match a CSS selector
 ```python
@@ -159,7 +159,7 @@ page.css('.product-list article')
 Find the first element that matches an XPath selector
 ```python
 page.xpath("//*[@id='products']/div/article")[0]
-# <data='<article class="product" data-id="1"><h3...' parent='<div class="product-list"> <article clas...'>
+# <data='<article class="product" data-id="1"><h3...' parent='<div class="product-list"> <article class...'>
 ```
 Find all elements that match an XPath selector
 ```python

--- a/scrapling/core/translator.py
+++ b/scrapling/core/translator.py
@@ -59,7 +59,7 @@ class XPathExpr(OriginalXPathExpr):
     ) -> Self:
         if not isinstance(other, XPathExpr):
             raise ValueError(  # pragma: no cover
-                f"Expressions of type {__name__}.XPathExpr can ony join expressions"
+                f"Expressions of type {__name__}.XPathExpr can only join expressions"
                 f" of the same type (or its descendants), got {type(other)}"
             )
         super().join(combiner, other, *args, **kwargs)

--- a/scrapling/engines/toolbelt/bypasses/window_chrome.js
+++ b/scrapling/engines/toolbelt/bypasses/window_chrome.js
@@ -196,7 +196,7 @@ const timingInfo = {
     },
     get firstPaintTime() {
         const fpEntry = performance.getEntriesByType('paint')[0] || {
-            startTime: timing.loadEventEnd / 1000, // Fallback if no navigation occured (`about:blank`)
+            startTime: timing.loadEventEnd / 1000, // Fallback if no navigation occurred (`about:blank`)
         };
         return toFixed(
             (fpEntry.startTime + performance.timeOrigin) / 1000,


### PR DESCRIPTION
Fixes #152

Fixed several typos in the codebase:

| File | Line | Fix |
|------|------|-----|
| `docs/overview.md` | 152 | `clas` → `class` |
| `docs/overview.md` | 162 | `clas` → `class` |
| `scrapling/core/translator.py` | 62 | `ony` → `only` |
| `scrapling/engines/toolbelt/bypasses/window_chrome.js` | 199 | `occured` → `occurred` |