### PR TITLE
fix: Selector.get_all_text() doesn't get all text #167

### DIFF
--- a/tests/parser/test_general.py
+++ b/tests/parser/test_general.py
@@ -327,32 +327,6 @@ def test_getting_all_text(page):
     assert page.get_all_text() != ""
 
 
-def test_getting_all_text_from_nested_content():
-    """Test getting all text preserves interleaved text nodes"""
-    html = """
-    <html>
-    <body>
-        <main>
-            string1
-            <b>string2</b>
-            string3
-            <div>
-                <span>string4</span>
-            </div>
-            string5
-            <script>ignored</script>
-            <style>ignored</style>
-        </main>
-    </body>
-    </html>
-    """
-
-    page = Selector(html, adaptive=False)
-    node = page.css("main")[0]
-
-    assert node.get_all_text("\n", strip=True) == "string1\nstring2\nstring3\nstring4\nstring5"
-
-
 def test_regex_on_text(page):
     """Test regex operations on text"""
     element = page.css('[data-id="1"] .price')[0]

--- a/tests/parser/test_parser_advanced.py
+++ b/tests/parser/test_parser_advanced.py
@@ -183,6 +183,33 @@ class TestAdvancedSelectors:
         text = page.get_all_text(valid_values=False)
         assert text != ""
 
+    def test_get_all_text_preserves_interleaved_text_nodes(self):
+        """Test get_all_text preserves interleaved text nodes"""
+        html = """
+        <html>
+        <body>
+            <main>
+                string1
+                <b>string2</b>
+                string3
+                <div>
+                    <span>string4</span>
+                </div>
+                string5
+                <script>ignored</script>
+                string6
+                <style>ignored</style>
+                string7
+            </main>
+        </body>
+        </html>
+        """
+
+        page = Selector(html, adaptive=False)
+        node = page.css("main")[0]
+
+        assert node.get_all_text("\n", strip=True) == "string1\nstring2\nstring3\nstring4\nstring5\nstring6\nstring7"
+
 
 class TestTextHandlerAdvanced:
     """Test advanced TextHandler functionality"""


### PR DESCRIPTION
- Selector.get_all_text() no longer ignores tail text nodes
- Added new unit test

<!--
  You are amazing! Thanks for contributing to Scrapling!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue in the additional information section.
-->


### Type of change:
<!--
  What type of change does your PR introduce to Scrapling?
  NOTE: Please, check at least 1 box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->



- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes an issue: fixes #167

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.
