### PR TITLE
fix: include tail text nodes in Selector.get_all_text

### DIFF
--- a/scrapling/parser.py
+++ b/scrapling/parser.py
@@ -304,13 +304,28 @@ class Selector(SelectorsGeneration):
                 ignored_elements.update(cast(list, _find_all_elements(element)))
 
         _all_strings = []
-        for node in self._root.iter():
-            if node not in ignored_elements:
-                text = node.text
-                if text and isinstance(text, str):
-                    processed_text = text.strip() if strip else text
-                    if not valid_values or processed_text.strip():
-                        _all_strings.append(processed_text)
+
+        def _append_if_valid(text: Any) -> None:
+            if text and isinstance(text, str):
+                processed_text = text.strip() if strip else text
+                if not valid_values or processed_text.strip():
+                    _all_strings.append(processed_text)
+
+        for text_node in self._root.xpath(".//text()"):
+            parent = text_node.getparent()
+            if parent is None:
+                continue
+
+            if parent in ignored_elements:
+                is_tail = bool(getattr(text_node, "is_tail", False))
+                if not is_tail:
+                    continue
+
+                grandparent = parent.getparent()
+                if grandparent is None or grandparent in ignored_elements:
+                    continue
+
+            _append_if_valid(str(text_node))
 
         return cast(TextHandler, TextHandler(separator).join(_all_strings))
 

--- a/tests/parser/test_parser_advanced.py
+++ b/tests/parser/test_parser_advanced.py
@@ -183,6 +183,35 @@ class TestAdvancedSelectors:
         text = page.get_all_text(valid_values=False)
         assert text != ""
 
+    def test_get_all_text_includes_tail_nodes(self):
+        """Ensure mixed text around nested tags is preserved"""
+        html = """
+        <html>
+        <body>
+            <main>
+                string1
+                <b>string2</b>
+                string3
+                <div><span>string4</span></div>
+                string5
+            </main>
+        </body>
+        </html>
+        """
+
+        page = Selector(html)
+        node = page.css("main")[0]
+
+        assert node.get_all_text("\n", strip=True) == "string1\nstring2\nstring3\nstring4\nstring5"
+
+    def test_get_all_text_keeps_ignored_tag_tail_text(self):
+        """Text after ignored tags should still be included"""
+        html = "<div>start<script>ignored</script>after<script>ignored2</script>end</div>"
+
+        page = Selector(html)
+
+        assert page.get_all_text(separator="|", strip=True) == "start|after|end"
+
 
 class TestTextHandlerAdvanced:
     """Test advanced TextHandler functionality"""


### PR DESCRIPTION
## Summary\n- include text node tails when collecting text so mixed content isn't dropped\n- preserve document order by iterating XPath text nodes\n- keep tail text that follows ignored tags while still excluding ignored tag content\n- add regression tests for nested-tag tails and ignored-tag tails\n\n## Validation\n- source .venv311/bin/activate && python -m pytest tests/parser/test_parser_advanced.py -k "get_all_text_includes_tail_nodes or get_all_text_keeps_ignored_tag_tail_text or text_operations_edge_cases"\n- source .venv311/bin/activate && python -m pytest tests/parser/test_general.py\n\nFixes #167