### PR TITLE
fix(mcp): use typing_extensions.TypedDict for SetCookieParam on Python 3.11

### DIFF
--- a/scrapling/core/_types.py
+++ b/scrapling/core/_types.py
@@ -4,7 +4,6 @@ Type definitions for type checking purposes.
 
 from typing import (
     TYPE_CHECKING,
-    TypedDict,
     TypeAlias,
     cast,
     overload,
@@ -32,7 +31,7 @@ from typing import (
     Coroutine,
     SupportsIndex,
 )
-from typing_extensions import Self, Unpack
+from typing_extensions import Self, Unpack, TypedDict
 
 # Proxy can be a string URL or a dict (Playwright format: {"server": "...", "username": "...", "password": "..."})
 ProxyType = Union[str, Dict[str, str]]

--- a/tests/ai/test_ai_mcp.py
+++ b/tests/ai/test_ai_mcp.py
@@ -1,3 +1,6 @@
+from typing import get_type_hints
+
+from pydantic import TypeAdapter
 import pytest
 import pytest_httpbin
 
@@ -15,6 +18,11 @@ class TestMCPServer:
     @pytest.fixture
     def server(self):
         return ScraplingMCPServer()
+
+    def test_fetch_cookies_annotation_is_pydantic_compatible(self):
+        """`cookies` hint should stay compatible with Pydantic model generation on Python < 3.12."""
+        cookies_hint = get_type_hints(ScraplingMCPServer.fetch)["cookies"]
+        TypeAdapter(cookies_hint)
 
     def test_get_tool(self, server, test_url):
         """Test the get tool method"""


### PR DESCRIPTION
## Summary
- switch `SetCookieParam` to use `typing_extensions.TypedDict` (instead of stdlib `typing.TypedDict`) so Pydantic can build MCP tool schemas on Python < 3.12
- add a regression test that validates `ScraplingMCPServer.fetch`'s `cookies` annotation can be wrapped by `pydantic.TypeAdapter`

## Verification
- `pytest -q tests/ai/test_ai_mcp.py -k pydantic_compatible`
- manually confirmed `scrapling mcp` no longer crashes at startup on Python 3.11 with `PydanticUserError`

Closes #163.
