### PR TITLE
fix: support MCP startup on Python < 3.12

### DIFF
--- a/scrapling/core/_types.py
+++ b/scrapling/core/_types.py
@@ -4,7 +4,6 @@ Type definitions for type checking purposes.
 
 from typing import (
     TYPE_CHECKING,
-    TypedDict,
     TypeAlias,
     cast,
     overload,
@@ -32,7 +31,7 @@ from typing import (
     Coroutine,
     SupportsIndex,
 )
-from typing_extensions import Self, Unpack
+from typing_extensions import Self, TypedDict, Unpack
 
 # Proxy can be a string URL or a dict (Playwright format: {"server": "...", "username": "...", "password": "..."})
 ProxyType = Union[str, Dict[str, str]]

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -1,0 +1,14 @@
+from pydantic import create_model
+
+from scrapling.core._types import SetCookieParam, TypedDict
+
+
+def test_typed_dict_uses_typing_extensions():
+    assert TypedDict.__module__ == "typing_extensions"
+
+
+def test_set_cookie_param_typed_dict_is_pydantic_compatible():
+    model = create_model("Args", cookies=(list[SetCookieParam] | None, None))
+    schema = model.model_json_schema()
+
+    assert "cookies" in schema["properties"]


### PR DESCRIPTION
## Summary\n- switch Scrapling's shared TypedDict import to typing_extensions for Python < 3.12 compatibility\n- keep the rest of the MCP/browser type surface unchanged\n- add a focused regression test that reproduces Pydantic model generation against SetCookieParam\n\nFixes #163\n\n## Validation\n- python3.11 -m pytest tests/core/test_types.py -q\n- python3.11 reproduction: create_model('Args', cookies=(list[SetCookieParam] | None, None))\n- git diff --check