### PR TITLE
fix: pass max_pages to parent in sync DynamicSession and StealthySession

### DIFF
--- a/scrapling/engines/_browsers/_controllers.py
+++ b/scrapling/engines/_browsers/_controllers.py
@@ -66,7 +66,7 @@ class DynamicSession(SyncSession, DynamicSessionMixin):
         :param additional_args: Additional arguments to be passed to Playwright's context as additional settings, and it takes higher priority than Scrapling's settings.
         """
         self.__validate__(**kwargs)
-        super().__init__()
+        super().__init__(max_pages=self._config.max_pages)
 
     def start(self):
         """Create a browser for this instance and context."""

--- a/scrapling/engines/_browsers/_stealth.py
+++ b/scrapling/engines/_browsers/_stealth.py
@@ -74,7 +74,7 @@ class StealthySession(SyncSession, StealthySessionMixin):
         :param additional_args: Additional arguments to be passed to Playwright's context as additional settings, and it takes higher priority than Scrapling's settings.
         """
         self.__validate__(**kwargs)
-        super().__init__()
+        super().__init__(max_pages=self._config.max_pages)
 
     def start(self) -> None:
         """Create a browser for this instance and context."""


### PR DESCRIPTION
## What

Forward `self._config.max_pages` to `super().__init__()` in the sync versions of `DynamicSession` and `StealthySession`.

## Why

The async counterparts already do this correctly:

```python
# AsyncDynamicSession (correct)
super().__init__(max_pages=self._config.max_pages)

# AsyncStealthySession (correct)
super().__init__(max_pages=self._config.max_pages)
```

But the sync versions both call `super().__init__()` without the parameter:

```python
# DynamicSession (before this fix)
super().__init__()  # always max_pages=1

# StealthySession (before this fix)
super().__init__()  # always max_pages=1
```

This means `SyncSession.__init__` always creates a `PagePool(1)` regardless of the user's `max_pages` configuration.

## Changes

- `scrapling/engines/_browsers/_controllers.py`: `DynamicSession.__init__`
- `scrapling/engines/_browsers/_stealth.py`: `StealthySession.__init__`

Two one-line changes. No new dependencies, no test changes needed — the existing session tests cover the initialization path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)