### PR TITLE
feat: add Akamai Bot Manager challenge solver

### DIFF
--- a/scrapling/engines/_browsers/_base.py
+++ b/scrapling/engines/_browsers/_base.py
@@ -532,3 +532,7 @@ class StealthySessionMixin(BaseSessionMixin):
             return "embedded"
 
         return None
+
+    @staticmethod
+    def _detect_akamai(page_content: str) -> bool:
+        return "<title>Challenge Page</title>" in page_content or "/.well-known/sbsd" in page_content

--- a/scrapling/engines/_browsers/_stealth.py
+++ b/scrapling/engines/_browsers/_stealth.py
@@ -184,6 +184,24 @@ class StealthySession(SyncSession, StealthySessionMixin):
                     log.info("Looks like Cloudflare captcha is still present, solving again")
                     return self._cloudflare_solver(page)
 
+    def _akamai_solver(self, page: Page) -> None:  # pragma: no cover
+        self._wait_for_networkidle(page, timeout=5000)
+        if not self._detect_akamai(ResponseFactory._get_page_content(page)):
+            log.error("No Akamai challenge found.")
+            return None
+
+        log.info("Akamai Bot Manager challenge detected, waiting for resolution...")
+        attempts = 0
+        while self._detect_akamai(ResponseFactory._get_page_content(page)):
+            if attempts >= 300:
+                log.info("Akamai challenge did not resolve after 30s, continuing...")
+                break
+            page.wait_for_timeout(100)
+            attempts += 1
+
+        self._wait_for_page_stability(page, True, False)
+        log.info("Akamai challenge resolved.")
+
     def fetch(self, url: str, **kwargs: Unpack[StealthFetchParams]) -> Response:
         """Opens up the browser and do your request based on your chosen options.
 
@@ -240,6 +258,10 @@ class StealthySession(SyncSession, StealthySessionMixin):
                     if params.solve_cloudflare:
                         self._cloudflare_solver(page)
                         # Make sure the page is fully loaded after the captcha
+                        self._wait_for_page_stability(page, params.load_dom, params.network_idle)
+
+                    if params.solve_akamai:
+                        self._akamai_solver(page)
                         self._wait_for_page_stability(page, params.load_dom, params.network_idle)
 
                     if params.page_action:
@@ -437,6 +459,24 @@ class AsyncStealthySession(AsyncSession, StealthySessionMixin):
                     log.info("Looks like Cloudflare captcha is still present, solving again")
                     return await self._cloudflare_solver(page)
 
+    async def _akamai_solver(self, page: async_Page) -> None:  # pragma: no cover
+        await self._wait_for_networkidle(page, timeout=5000)
+        if not self._detect_akamai(await ResponseFactory._get_async_page_content(page)):
+            log.error("No Akamai challenge found.")
+            return None
+
+        log.info("Akamai Bot Manager challenge detected, waiting for resolution...")
+        attempts = 0
+        while self._detect_akamai(await ResponseFactory._get_async_page_content(page)):
+            if attempts >= 300:
+                log.info("Akamai challenge did not resolve after 30s, continuing...")
+                break
+            await page.wait_for_timeout(100)
+            attempts += 1
+
+        await self._wait_for_page_stability(page, True, False)
+        log.info("Akamai challenge resolved.")
+
     async def fetch(self, url: str, **kwargs: Unpack[StealthFetchParams]) -> Response:
         """Opens up the browser and do your request based on your chosen options.
 
@@ -494,6 +534,10 @@ class AsyncStealthySession(AsyncSession, StealthySessionMixin):
                     if params.solve_cloudflare:
                         await self._cloudflare_solver(page)
                         # Make sure the page is fully loaded after the captcha
+                        await self._wait_for_page_stability(page, params.load_dom, params.network_idle)
+
+                    if params.solve_akamai:
+                        await self._akamai_solver(page)
                         await self._wait_for_page_stability(page, params.load_dom, params.network_idle)
 
                     if params.page_action:

--- a/scrapling/engines/_browsers/_types.py
+++ b/scrapling/engines/_browsers/_types.py
@@ -112,7 +112,9 @@ class StealthSession(PlaywrightSession, total=False):
     hide_canvas: bool
     block_webrtc: bool
     solve_cloudflare: bool
+    solve_akamai: bool
 
 
 class StealthFetchParams(PlaywrightFetchParams, total=False):
     solve_cloudflare: bool
+    solve_akamai: bool

--- a/scrapling/engines/_browsers/_validators.py
+++ b/scrapling/engines/_browsers/_validators.py
@@ -124,12 +124,15 @@ class StealthConfig(PlaywrightConfig, kw_only=True, frozen=False, weakref=True):
     hide_canvas: bool = False
     block_webrtc: bool = False
     solve_cloudflare: bool = False
+    solve_akamai: bool = False
 
     def __post_init__(self):
         """Custom validation after msgspec validation"""
         super(StealthConfig, self).__post_init__()
         # Cloudflare timeout adjustment
         if self.solve_cloudflare and self.timeout < 60_000:
+            self.timeout = 60_000
+        if self.solve_akamai and self.timeout < 60_000:
             self.timeout = 60_000
 
 
@@ -149,6 +152,7 @@ class _fetch_params:
     load_dom: bool
     blocked_domains: Optional[Set[str]]
     solve_cloudflare: bool
+    solve_akamai: bool
     selector_config: Dict
 
 
@@ -178,15 +182,17 @@ def validate_fetch(
             field: getattr(validated_config, field) for field in overrides.keys() if hasattr(validated_config, field)
         }
 
-        # Preserve solve_cloudflare if the user explicitly provided it, even if the model doesn't have it
         if "solve_cloudflare" in overrides:
             validated_dict["solve_cloudflare"] = overrides["solve_cloudflare"]
+        if "solve_akamai" in overrides:
+            validated_dict["solve_akamai"] = overrides["solve_akamai"]
 
         # Start with session defaults, then overwrite with validated overrides
         result.update(validated_dict)
 
     # solve_cloudflare defaults to False for models that don't have it (PlaywrightConfig)
     result.setdefault("solve_cloudflare", False)
+    result.setdefault("solve_akamai", False)
     result.setdefault("blocked_domains", None)
 
     return _fetch_params(**result)

--- a/tests/fetchers/sync/test_stealth_session.py
+++ b/tests/fetchers/sync/test_stealth_session.py
@@ -92,3 +92,10 @@ class TestStealthySession:
             result = StealthySession._detect_cloudflare(page_content)
             assert result is None
             assert session.fetch(self.status_200).status == 200
+
+            # Test Akamai detection
+            for akamai_signal in ("<title>Challenge Page</title>", "/.well-known/sbsd"):
+                page_content = f"<html><head>{akamai_signal}</head><body></body></html>"
+                assert session._detect_akamai(page_content) is True
+
+            assert StealthySession._detect_akamai("<html><body>Regular page</body></html>") is False

--- a/tests/fetchers/test_validator.py
+++ b/tests/fetchers/test_validator.py
@@ -99,3 +99,14 @@ class TestValidators:
         config = validate(params, StealthConfig)
 
         assert config.blocked_domains == {"ads.example.com"}
+
+    def test_stealth_config_akamai_timeout(self):
+        """Test StealthConfig timeout adjustment for Akamai"""
+        params = {
+            "solve_akamai": True,
+            "timeout": 10000
+        }
+
+        config = validate(params, StealthConfig)
+
+        assert config.timeout == 60000


### PR DESCRIPTION
Closes #212

Adds `solve_akamai=True` support to `StealthySession` and `AsyncStealthySession`, mirroring the existing `solve_cloudflare` pattern.

- `_detect_akamai()` checks for `<title>Challenge Page</title>` or `/.well-known/sbsd` in page content
- `_akamai_solver()` waits for the challenge to resolve (Akamai triggers `location.reload` automatically via XHR intercept once the SW handshake completes)
- Timeout is auto-bumped to 60s when `solve_akamai=True`