### PR TITLE
fix: use Union[int, float] instead of Annotated[int, float] for Seconds type

### DIFF
--- a/scrapling/engines/_browsers/_validators.py
+++ b/scrapling/engines/_browsers/_validators.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Union
 from functools import lru_cache
 from urllib.parse import urlparse
 from dataclasses import dataclass, fields
@@ -53,7 +53,7 @@ def _is_invalid_cdp_url(cdp_url: str) -> bool | str:
 # Type aliases for cleaner annotations
 PagesCount = Annotated[int, Meta(ge=1, le=50)]
 RetriesCount = Annotated[int, Meta(ge=1, le=10)]
-Seconds = Annotated[int, float, Meta(ge=0)]
+Seconds = Annotated[Union[int, float], Meta(ge=0)]
 
 
 class PlaywrightConfig(Struct, kw_only=True, frozen=False, weakref=True):


### PR DESCRIPTION
## Problem

In `scrapling/engines/_browsers/_validators.py`, the `Seconds` type alias is incorrectly defined as:

```python
Seconds = Annotated[int, float, Meta(ge=0)]
```

Per [PEP 593](https://peps.python.org/pep-0593/) / `typing.Annotated`, **only the first argument is the type**; subsequent arguments are metadata annotations. This means `float` is silently treated as a metadata value, **not** a type union. The actual validated type is `int` only.

As a result, passing `wait=0.5` or `timeout=1.5` silently truncates the float value to int, leading to unexpected behaviour with no error raised.

## Fix

Use `Union[int, float]` as the first (type) argument:

```python
Seconds = Annotated[Union[int, float], Meta(ge=0)]
```

Also adds `Union` to the `from typing import` statement for backward compatibility (Python < 3.10).

## Changes

- `scrapling/engines/_browsers/_validators.py`
  - Add `Union` to `from typing import Annotated, Union`
  - Change `Seconds = Annotated[int, float, Meta(ge=0)]` → `Seconds = Annotated[Union[int, float], Meta(ge=0)]`

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>