### PR TITLE
feat(mcp): add screenshot tool for capturing page screenshots

### DIFF
--- a/scrapling/core/ai.py
+++ b/scrapling/core/ai.py
@@ -1,4 +1,5 @@
 from uuid import uuid4
+from base64 import b64encode
 from asyncio import gather
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
@@ -63,6 +64,18 @@ class SessionClosedModel(BaseModel):
     message: str = Field(description="A confirmation message.")
 
 
+ScreenshotType = Literal["png", "jpeg"]
+
+
+class ScreenshotModel(BaseModel):
+    """Screenshot result with base64-encoded image data."""
+
+    url: str = Field(description="The URL of the page that was captured.")
+    image_data: str = Field(description="Base64-encoded image data.")
+    image_type: ScreenshotType = Field(description="The image format: 'png' or 'jpeg'.")
+    full_page: bool = Field(description="Whether the screenshot captures the full scrollable page.")
+
+
 @dataclass
 class _SessionEntry:
     session: Any  # AsyncDynamicSession | AsyncStealthySession
@@ -118,6 +131,15 @@ class ScraplingMCPServer:
                 f"Session '{session_id}' is a '{entry.session_type}' session, but this tool requires a "
                 f"'{expected_type}' session. Use the matching fetch tool for your session type."
             )
+        return entry
+
+    def _get_session_any_type(self, session_id: str) -> _SessionEntry:
+        """Look up a session by ID without enforcing a specific type."""
+        entry = self._sessions.get(session_id)
+        if entry is None:
+            raise ValueError(f"Session '{session_id}' not found. Use list_sessions to see active sessions.")
+        if not entry.session._is_alive:
+            raise ValueError(f"Session '{session_id}' is no longer alive. Open a new session.")
         return entry
 
     async def open_session(
@@ -252,6 +274,119 @@ class ScraplingMCPServer:
             )
             for sid, entry in self._sessions.items()
         ]
+
+    async def screenshot(
+        self,
+        url: str,
+        image_type: ScreenshotType = "png",
+        full_page: bool = False,
+        quality: Optional[int] = None,
+        wait: int | float = 0,
+        wait_selector: Optional[str] = None,
+        wait_selector_state: SelectorWaitStates = "attached",
+        network_idle: bool = False,
+        timeout: int | float = 30000,
+        session_id: Optional[str] = None,
+        # Ad-hoc browser options (ignored when session_id is provided)
+        headless: bool = True,
+        proxy: Optional[str | Dict[str, str]] = None,
+        locale: str | None = None,
+        timezone_id: str | None = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        useragent: Optional[str] = None,
+        cookies: Sequence[SetCookieParam] | None = None,
+        google_search: bool = True,
+        disable_resources: bool = False,
+    ) -> ScreenshotModel:
+        """Take a screenshot of a web page and return the image as base64-encoded data.
+        Supports both ad-hoc usage and persistent sessions. When a `session_id` is provided,
+        the existing browser session is reused; otherwise a temporary browser is launched.
+
+        :param url: The URL to navigate to and capture.
+        :param image_type: Image format for the screenshot. Defaults to "png". Use "jpeg" for smaller file sizes.
+        :param full_page: When True, captures the full scrollable page instead of just the viewport. Defaults to False.
+        :param quality: Image quality for JPEG screenshots (0-100). Ignored for PNG. Defaults to None.
+        :param wait: Time in milliseconds to wait after page load before capturing. Defaults to 0.
+        :param wait_selector: Optional CSS selector to wait for before taking the screenshot.
+        :param wait_selector_state: State to wait for the selector. Defaults to "attached".
+        :param network_idle: Wait for the page until there are no network connections for at least 500 ms.
+        :param timeout: Timeout in milliseconds for page operations. Defaults to 30,000.
+        :param session_id: Optional session ID from open_session. Reuses an existing browser session.
+        :param headless: Run the browser in headless mode. Ignored when session_id is provided.
+        :param proxy: Proxy configuration. Ignored when session_id is provided.
+        :param locale: Browser locale. Ignored when session_id is provided.
+        :param timezone_id: Browser timezone. Ignored when session_id is provided.
+        :param extra_headers: Extra HTTP headers. Ignored when session_id is provided.
+        :param useragent: Custom user agent string. Ignored when session_id is provided.
+        :param cookies: Cookies to set. Ignored when session_id is provided.
+        :param google_search: Set Google referer header. Defaults to True.
+        :param disable_resources: Drop requests for fonts, images, etc. for faster loading. Defaults to False.
+        """
+        screenshot_kwargs: Dict[str, Any] = {
+            "type": image_type,
+            "full_page": full_page,
+        }
+        if image_type == "jpeg" and quality is not None:
+            screenshot_kwargs["quality"] = quality
+
+        # Mutable container to capture the screenshot bytes from inside page_action
+        captured: List[bytes] = []
+        captured_url: List[str] = []
+
+        async def _capture_screenshot(page: Any) -> None:
+            """page_action callback that captures the screenshot before the page closes."""
+            captured.append(await page.screenshot(**screenshot_kwargs))
+            captured_url.append(page.url)
+
+        if session_id:
+            entry = self._get_session_any_type(session_id)
+            session = entry.session
+
+            fetch_kwargs: Dict[str, Any] = {
+                "wait": wait,
+                "timeout": timeout,
+                "google_search": google_search,
+                "disable_resources": disable_resources,
+                "network_idle": network_idle,
+                "page_action": _capture_screenshot,
+            }
+            if extra_headers:
+                fetch_kwargs["extra_headers"] = extra_headers
+            if wait_selector:
+                fetch_kwargs["wait_selector"] = wait_selector
+                fetch_kwargs["wait_selector_state"] = wait_selector_state
+
+            await session.fetch(url, **fetch_kwargs)
+        else:
+            async with AsyncDynamicSession(
+                wait=wait,
+                proxy=proxy,
+                locale=locale,
+                timeout=timeout,
+                cookies=cookies,
+                headless=headless,
+                block_ads=True,
+                max_pages=1,
+                useragent=useragent,
+                timezone_id=timezone_id,
+                network_idle=network_idle,
+                wait_selector=wait_selector,
+                google_search=google_search,
+                extra_headers=extra_headers,
+                disable_resources=disable_resources,
+                wait_selector_state=wait_selector_state,
+            ) as session:
+                await session.fetch(url, page_action=_capture_screenshot)
+
+        if not captured:
+            raise RuntimeError(f"Failed to capture screenshot for {url}")
+
+        return ScreenshotModel(
+            url=captured_url[0] if captured_url else url,
+            image_data=b64encode(captured[0]).decode("ascii"),
+            image_type=image_type,
+            full_page=full_page,
+        )
 
     @staticmethod
     async def get(
@@ -826,6 +961,13 @@ class ScraplingMCPServer:
             self.bulk_stealthy_fetch,
             title="bulk_stealthy_fetch",
             description=self.bulk_stealthy_fetch.__doc__,
+            structured_output=True,
+        )
+        # Screenshot tool
+        server.add_tool(
+            self.screenshot,
+            title="screenshot",
+            description=self.screenshot.__doc__,
             structured_output=True,
         )
         server.run(transport="stdio" if not http else "streamable-http")

--- a/tests/ai/test_ai_mcp.py
+++ b/tests/ai/test_ai_mcp.py
@@ -1,9 +1,12 @@
+import base64
+
 import pytest
 import pytest_httpbin
 
 from scrapling.core.ai import (
     ScraplingMCPServer,
     ResponseModel,
+    ScreenshotModel,
     SessionInfo,
     SessionCreatedModel,
     SessionClosedModel,
@@ -198,3 +201,75 @@ class TestNormalizeCredentials:
     def test_missing_username_raises(self):
         with pytest.raises(ValueError, match="username"):
             _normalize_credentials({"password": "pass"})
+
+
+@pytest_httpbin.use_class_based_httpbin
+class TestScreenshot:
+    """Test MCP screenshot functionality"""
+
+    @pytest.fixture(scope="class")
+    def test_url(self, httpbin):
+        return f"{httpbin.url}/html"
+
+    @pytest.fixture
+    def server(self):
+        return ScraplingMCPServer()
+
+    @pytest.mark.asyncio
+    async def test_screenshot_ad_hoc_png(self, server, test_url):
+        """Test taking a PNG screenshot without a session (ad-hoc browser)"""
+        result = await server.screenshot(url=test_url, image_type="png", headless=True)
+        assert isinstance(result, ScreenshotModel)
+        assert result.image_type == "png"
+        assert result.full_page is False
+        # Verify valid base64 that decodes to a PNG
+        raw = base64.b64decode(result.image_data)
+        assert raw[:4] == b"\x89PNG"
+
+    @pytest.mark.asyncio
+    async def test_screenshot_ad_hoc_jpeg(self, server, test_url):
+        """Test taking a JPEG screenshot"""
+        result = await server.screenshot(url=test_url, image_type="jpeg", quality=80, headless=True)
+        assert isinstance(result, ScreenshotModel)
+        assert result.image_type == "jpeg"
+        raw = base64.b64decode(result.image_data)
+        assert raw[:2] == b"\xff\xd8"  # JPEG magic bytes
+
+    @pytest.mark.asyncio
+    async def test_screenshot_full_page(self, server, test_url):
+        """Test full-page screenshot"""
+        result = await server.screenshot(url=test_url, full_page=True, headless=True)
+        assert isinstance(result, ScreenshotModel)
+        assert result.full_page is True
+        assert len(result.image_data) > 0
+
+    @pytest.mark.asyncio
+    async def test_screenshot_with_session(self, server, test_url):
+        """Test screenshot using a persistent session"""
+        session = await server.open_session(session_type="dynamic", headless=True)
+        session_id = session.session_id
+
+        result = await server.screenshot(url=test_url, session_id=session_id)
+        assert isinstance(result, ScreenshotModel)
+        raw = base64.b64decode(result.image_data)
+        assert raw[:4] == b"\x89PNG"
+
+        await server.close_session(session_id)
+
+    @pytest.mark.asyncio
+    async def test_screenshot_with_stealthy_session(self, server, test_url):
+        """Test screenshot using a stealthy session"""
+        session = await server.open_session(session_type="stealthy", headless=True)
+        session_id = session.session_id
+
+        result = await server.screenshot(url=test_url, session_id=session_id)
+        assert isinstance(result, ScreenshotModel)
+        assert len(result.image_data) > 0
+
+        await server.close_session(session_id)
+
+    @pytest.mark.asyncio
+    async def test_screenshot_nonexistent_session(self, server, test_url):
+        """Test screenshot with invalid session ID raises error"""
+        with pytest.raises(ValueError, match="not found"):
+            await server.screenshot(url=test_url, session_id="nonexistent")


### PR DESCRIPTION
## Summary

Implements #244 — adds a `screenshot` MCP tool that captures web page screenshots and returns them as base64-encoded image data.

## Changes

### New types
- `ScreenshotModel` — response model with `url`, `image_data` (base64), `image_type` (png/jpeg), and `full_page` fields
- `ScreenshotType` — literal type for image format selection

### New methods on `ScraplingMCPServer`
- `screenshot()` — takes a screenshot of a URL, supporting both ad-hoc and session-based usage
- `_get_session_any_type()` — helper that looks up a session by ID without enforcing dynamic/stealthy type (screenshot works with either)

### How it works

The core challenge is that Scrapling's `fetch()` manages the page lifecycle internally — the page is closed in `_page_generator`'s finally block before we can interact with it. The solution uses the existing `page_action` callback mechanism: an async closure captures the screenshot bytes from the live Playwright page during the fetch, before the page is cleaned up.

**Ad-hoc mode** (no `session_id`): Creates a temporary `AsyncDynamicSession`, navigates to the URL, captures via `page_action`, and tears down.

**Session mode** (`session_id` provided): Reuses an existing persistent session (either dynamic or stealthy), passing `page_action` through the fetch kwargs.

### Supported options
- `image_type`: `"png"` (default) or `"jpeg"`
- `full_page`: capture full scrollable page vs viewport only
- `quality`: JPEG quality (0-100)
- `wait` / `wait_selector` / `network_idle`: page readiness controls
- All standard session creation params for ad-hoc mode

### Tests
6 new test cases in `tests/ai/test_ai_mcp.py`:
1. Ad-hoc PNG screenshot with magic byte verification
2. Ad-hoc JPEG screenshot with quality parameter
3. Full-page screenshot
4. Screenshot with persistent dynamic session
5. Screenshot with persistent stealthy session
6. Error handling for nonexistent session ID

All existing tests continue to pass (the 2 pre-existing `test_get_tool`/`test_bulk_get_tool` failures are a curl_cffi compatibility issue with the new `"safe"` redirect value, unrelated to this PR).