### PR TITLE
Replace pickle with orjson for checkpoint serialization (fixes #263)

### DIFF
--- a/agent-skill/Scrapling-Skill/references/spiders/architecture.md
+++ b/agent-skill/Scrapling-Skill/references/spiders/architecture.md
@@ -58,7 +58,7 @@ When a request comes in, the Session Manager routes it to the correct session ba
 
 ### Checkpoint System
 
-An optional system that, if enabled, saves the crawler's state (pending requests + seen URL fingerprints) to a pickle file on disk. Writes are atomic (temp file + rename) to prevent corruption. Checkpoints are saved periodically at a configurable interval and on graceful shutdown. Upon successful completion (not paused), checkpoint files are automatically cleaned up.
+An optional system that, if enabled, saves the crawler's state (pending requests + seen URL fingerprints) to a JSON file on disk. Writes are atomic (temp file + rename) to prevent corruption. Checkpoints are saved periodically at a configurable interval and on graceful shutdown. Upon successful completion (not paused), checkpoint files are automatically cleaned up.
 
 ### Response Cache
 

--- a/docs/spiders/architecture.md
+++ b/docs/spiders/architecture.md
@@ -67,7 +67,7 @@ When a request comes in, the Session Manager routes it to the correct session ba
 
 ### Checkpoint System
 
-An optional system that, if enabled, saves the crawler's state (pending requests + seen URL fingerprints) to a pickle file on disk. Writes are atomic (temp file + rename) to prevent corruption. Checkpoints are saved periodically at a configurable interval and on graceful shutdown. Upon successful completion (not paused), checkpoint files are automatically cleaned up.
+An optional system that, if enabled, saves the crawler's state (pending requests + seen URL fingerprints) to a JSON file on disk. Writes are atomic (temp file + rename) to prevent corruption. Checkpoints are saved periodically at a configurable interval and on graceful shutdown. Upon successful completion (not paused), checkpoint files are automatically cleaned up.
 
 ### Response Cache
 

--- a/scrapling/spiders/checkpoint.py
+++ b/scrapling/spiders/checkpoint.py
@@ -1,7 +1,7 @@
-import pickle
 from pathlib import Path
 from dataclasses import dataclass, field
 
+import orjson
 import anyio
 from anyio import Path as AsyncPath
 
@@ -20,10 +20,47 @@ class CheckpointData:
     seen: Set[bytes] = field(default_factory=set)
 
 
+def _checkpoint_to_dict(data: CheckpointData) -> dict:
+    """Convert CheckpointData to a JSON-serializable dict."""
+    requests = []
+    for req in data.requests:
+        state = req.__getstate__()
+        # Convert bytes _fp to hex string if present
+        fp = state.get("_fp")
+        if fp is not None:
+            state["_fp"] = fp.hex()
+        requests.append(state)
+
+    return {
+        "requests": requests,
+        "seen": [fp.hex() for fp in data.seen],
+    }
+
+
+def _dict_to_checkpoint(d: dict, request_cls) -> CheckpointData:
+    """Convert a JSON dict back to CheckpointData."""
+    from scrapling.spiders.request import Request as Req
+
+    requests = []
+    for req_dict in d["requests"]:
+        # Restore bytes _fp from hex string
+        fp_hex = req_dict.get("_fp")
+        if fp_hex is not None:
+            req_dict["_fp"] = bytes.fromhex(fp_hex)
+
+        req = Req.__new__(Req)
+        req.__setstate__(req_dict)
+        requests.append(req)
+
+    seen = {bytes.fromhex(fp_hex) for fp_hex in d["seen"]}
+
+    return CheckpointData(requests=requests, seen=seen)
+
+
 class CheckpointManager:
     """Manages saving and loading checkpoint state to/from disk."""
 
-    CHECKPOINT_FILE = "checkpoint.pkl"
+    CHECKPOINT_FILE = "checkpoint.json"
 
     def __init__(self, crawldir: str | Path | AsyncPath, interval: float = 300.0):
         self.crawldir = AsyncPath(crawldir)
@@ -46,7 +83,10 @@ class CheckpointManager:
         temp_path = self._checkpoint_path.with_suffix(".tmp")
 
         try:
-            serialized = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)
+            serialized = orjson.dumps(
+                _checkpoint_to_dict(data),
+                option=orjson.OPT_INDENT_2,
+            )
             async with await anyio.open_file(temp_path, "wb") as f:
                 await f.write(serialized)
 
@@ -71,7 +111,8 @@ class CheckpointManager:
         try:
             async with await anyio.open_file(self._checkpoint_path, "rb") as f:
                 content = await f.read()
-                data: CheckpointData = pickle.loads(content)
+                d = orjson.loads(content)
+                data = _dict_to_checkpoint(d, None)
 
             log.info(f"Checkpoint loaded: {len(data.requests)} requests, {len(data.seen)} seen URLs")
             return data

--- a/tests/spiders/test_checkpoint.py
+++ b/tests/spiders/test_checkpoint.py
@@ -1,11 +1,11 @@
 """Tests for the CheckpointManager and CheckpointData classes."""
 
-import pickle
 import tempfile
 from pathlib import Path
 
 import pytest
 import anyio
+import orjson
 
 from scrapling.spiders.request import Request
 from scrapling.spiders.checkpoint import CheckpointData, CheckpointManager
@@ -35,18 +35,23 @@ class TestCheckpointData:
         assert data.requests[0].url == "https://example.com/1"
         assert data.seen == {"url1", "url2", "url3"}
 
-    def test_pickle_roundtrip(self):
-        """Test that CheckpointData can be pickled and unpickled."""
+    def test_json_roundtrip(self):
+        """Test that CheckpointData can be serialized to JSON and back."""
+        from scrapling.spiders.checkpoint import _checkpoint_to_dict, _dict_to_checkpoint
+
         requests = [Request("https://example.com", priority=5)]
-        seen = {"fingerprint1", "fingerprint2"}
+        seen = {b"fingerprint1", b"fingerprint2"}
         data = CheckpointData(requests=requests, seen=seen)
 
-        pickled = pickle.dumps(data)
-        restored = pickle.loads(pickled)
+        d = _checkpoint_to_dict(data)
+        json_bytes = orjson.dumps(d)
+        restored_d = orjson.loads(json_bytes)
+        restored = _dict_to_checkpoint(restored_d, None)
 
         assert len(restored.requests) == 1
         assert restored.requests[0].url == "https://example.com"
-        assert restored.seen == {"fingerprint1", "fingerprint2"}
+        assert restored.requests[0].priority == 5
+        assert restored.seen == {b"fingerprint1", b"fingerprint2"}
 
 
 class TestCheckpointManagerInit:
@@ -90,7 +95,7 @@ class TestCheckpointManagerInit:
         """Test that checkpoint file path is correctly constructed."""
         manager = CheckpointManager("/tmp/test_crawl")
 
-        expected_path = "/tmp/test_crawl/checkpoint.pkl"
+        expected_path = "/tmp/test_crawl/checkpoint.json"
         assert str(manager._checkpoint_path) == expected_path
 
 
@@ -120,12 +125,12 @@ class TestCheckpointManagerOperations:
 
         data = CheckpointData(
             requests=[Request("https://example.com")],
-            seen={"fp1", "fp2"},
+            seen={b"fp1", b"fp2"},
         )
 
         await manager.save(data)
 
-        checkpoint_path = crawl_dir / "checkpoint.pkl"
+        checkpoint_path = crawl_dir / "checkpoint.json"
         assert checkpoint_path.exists()
 
     @pytest.mark.asyncio
@@ -169,7 +174,7 @@ class TestCheckpointManagerOperations:
                 Request("https://example.com/1", priority=10),
                 Request("https://example.com/2", priority=5),
             ],
-            seen={"fp1", "fp2", "fp3"},
+            seen={b"fp1", b"fp2", b"fp3"},
         )
 
         await manager.save(original_data)
@@ -179,7 +184,7 @@ class TestCheckpointManagerOperations:
         assert len(loaded_data.requests) == 2
         assert loaded_data.requests[0].url == "https://example.com/1"
         assert loaded_data.requests[0].priority == 10
-        assert loaded_data.seen == {"fp1", "fp2", "fp3"}
+        assert loaded_data.seen == {b"fp1", b"fp2", b"fp3"}
 
     @pytest.mark.asyncio
     async def test_save_is_atomic(self, temp_dir: Path):
@@ -195,7 +200,7 @@ class TestCheckpointManagerOperations:
         assert not temp_path.exists()
 
         # Checkpoint file should exist
-        checkpoint_path = crawl_dir / "checkpoint.pkl"
+        checkpoint_path = crawl_dir / "checkpoint.json"
         assert checkpoint_path.exists()
 
     @pytest.mark.asyncio
@@ -208,7 +213,7 @@ class TestCheckpointManagerOperations:
         data = CheckpointData()
         await manager.save(data)
 
-        checkpoint_path = crawl_dir / "checkpoint.pkl"
+        checkpoint_path = crawl_dir / "checkpoint.json"
         assert checkpoint_path.exists()
 
         # Cleanup should remove it
@@ -230,8 +235,8 @@ class TestCheckpointManagerOperations:
         crawl_dir = temp_dir / "crawl"
         crawl_dir.mkdir(parents=True)
 
-        checkpoint_path = crawl_dir / "checkpoint.pkl"
-        checkpoint_path.write_bytes(b"not valid pickle data")
+        checkpoint_path = crawl_dir / "checkpoint.json"
+        checkpoint_path.write_bytes(b"not valid json data")
 
         manager = CheckpointManager(crawl_dir)
 
@@ -247,14 +252,14 @@ class TestCheckpointManagerOperations:
         # First save
         data1 = CheckpointData(
             requests=[Request("https://example.com/1")],
-            seen={"fp1"},
+            seen={b"fp1"},
         )
         await manager.save(data1)
 
         # Second save
         data2 = CheckpointData(
             requests=[Request("https://example.com/2"), Request("https://example.com/3")],
-            seen={"fp2", "fp3"},
+            seen={b"fp2", b"fp3"},
         )
         await manager.save(data2)
 
@@ -264,7 +269,7 @@ class TestCheckpointManagerOperations:
         assert loaded is not None
         assert len(loaded.requests) == 2
         assert loaded.requests[0].url == "https://example.com/2"
-        assert loaded.seen == {"fp2", "fp3"}
+        assert loaded.seen == {b"fp2", b"fp3"}
 
 
 class TestCheckpointManagerEdgeCases:
@@ -300,7 +305,7 @@ class TestCheckpointManagerEdgeCases:
             Request(f"https://example.com/{i}", priority=i % 10)
             for i in range(1000)
         ]
-        seen = {f"fp_{i}" for i in range(2000)}
+        seen = {f"fp_{i}".encode() for i in range(2000)}
 
         data = CheckpointData(requests=requests, seen=seen)
         await manager.save(data)
@@ -339,3 +344,24 @@ class TestCheckpointManagerEdgeCases:
         assert restored.dont_filter is True
         assert restored.meta == {"item_id": 123, "page": 5}
         assert restored._session_kwargs == {"proxy": "http://proxy:8080"}
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_file_is_valid_json(self, temp_dir: Path):
+        """Test that checkpoint file is human-readable JSON."""
+        manager = CheckpointManager(temp_dir / "crawl")
+
+        data = CheckpointData(
+            requests=[Request("https://example.com", priority=5)],
+            seen={b"fp1"},
+        )
+        await manager.save(data)
+
+        checkpoint_path = temp_dir / "crawl" / "checkpoint.json"
+        content = checkpoint_path.read_text()
+
+        # Should be valid JSON
+        parsed = orjson.loads(content)
+        assert "requests" in parsed
+        assert "seen" in parsed
+        assert len(parsed["requests"]) == 1
+        assert parsed["requests"][0]["url"] == "https://example.com"

--- a/tests/spiders/test_engine.py
+++ b/tests/spiders/test_engine.py
@@ -608,7 +608,7 @@ class TestCheckpointMethods:
             await engine._save_checkpoint()
 
             # Verify checkpoint file exists
-            checkpoint_path = Path(tmpdir) / "checkpoint.pkl"
+            checkpoint_path = Path(tmpdir) / "checkpoint.json"
             assert checkpoint_path.exists()
 
     @pytest.mark.asyncio
@@ -745,7 +745,7 @@ class TestCrawl:
 
             await engine.crawl()
 
-            checkpoint_path = Path(tmpdir) / "checkpoint.pkl"
+            checkpoint_path = Path(tmpdir) / "checkpoint.json"
             assert not checkpoint_path.exists()  # Cleaned up
 
     @pytest.mark.asyncio

--- a/tests/spiders/test_force_stop_checkpoint.py
+++ b/tests/spiders/test_force_stop_checkpoint.py
@@ -135,7 +135,7 @@ class TestForceStopCheckpointPreservation:
             session = MockSession(delay=0.5)
             engine = _make_engine(spider, session, crawldir=tmpdir, interval=0)
 
-            checkpoint_path = Path(tmpdir) / "checkpoint.pkl"
+            checkpoint_path = Path(tmpdir) / "checkpoint.json"
 
             async def force_stop_after_delay():
                 """Simulate two rapid Ctrl+C presses."""
@@ -165,7 +165,7 @@ class TestForceStopCheckpointPreservation:
             session = MockSession(delay=0.3)
             engine = _make_engine(spider, session, crawldir=tmpdir, interval=0)
 
-            checkpoint_path = Path(tmpdir) / "checkpoint.pkl"
+            checkpoint_path = Path(tmpdir) / "checkpoint.json"
 
             async def pause_after_delay():
                 await anyio.sleep(0.1)
@@ -214,7 +214,7 @@ class TestForceStopCheckpointPreservation:
 
             await engine.crawl()
 
-            checkpoint_path = Path(tmpdir) / "checkpoint.pkl"
+            checkpoint_path = Path(tmpdir) / "checkpoint.json"
             # No pause → checkpoint should be cleaned up
             assert not checkpoint_path.exists()
             assert engine.paused is False
@@ -257,7 +257,7 @@ class TestForceStopCheckpointPreservation:
                 tg.start_soon(pause1)
                 await engine1.crawl()
 
-            checkpoint_path = Path(tmpdir) / "checkpoint.pkl"
+            checkpoint_path = Path(tmpdir) / "checkpoint.json"
             assert checkpoint_path.exists(), "First run should create checkpoint"
             first_checkpoint_size = checkpoint_path.stat().st_size
 


### PR DESCRIPTION
## Summary

Replaces the pickle-based checkpoint serialization with **orjson** (JSON) to address the security concerns raised in #263.

### Problem

The checkpoint system used `pickle` for serializing crawler state to disk. Pickle deserialization is inherently unsafe — loading a crafted `.pkl` file can lead to **Remote Code Execution (RCE)** because pickle can instantiate arbitrary objects and call functions during loading.

### Solution

Replaced `pickle.dumps()`/`pickle.loads()` with `orjson.dumps()`/`orjson.loads()` in the checkpoint manager. Added two helper functions to handle serialization:

- `_checkpoint_to_dict()`: Converts `CheckpointData` (including `Request` objects and `bytes` in the seen set) to a JSON-serializable dict. Uses `Request.__getstate__()` which already handles callback serialization, and hex-encodes `bytes` fields.
- `_dict_to_checkpoint()`: Reconstructs `CheckpointData` from the JSON dict, restoring `Request` objects via `__setstate__()` and decoding hex strings back to `bytes`.

### Changes

| File | Change |
|------|--------|
| `scrapling/spiders/checkpoint.py` | Replaced `import pickle` with `import orjson`; added `_checkpoint_to_dict()` and `_dict_to_checkpoint()` helpers; changed `CHECKPOINT_FILE` from `checkpoint.pkl` to `checkpoint.json` |
| `tests/spiders/test_checkpoint.py` | Updated all tests to use JSON roundtrip and `checkpoint.json` filename; added `test_checkpoint_file_is_valid_json` test |
| `tests/spiders/test_engine.py` | Updated checkpoint path references to `.json` |
| `tests/spiders/test_force_stop_checkpoint.py` | Updated checkpoint path references to `.json` |
| `docs/spiders/architecture.md` | Updated docs to reference JSON |
| `agent-skill/.../architecture.md` | Updated docs to reference JSON |

### Benefits

- **Security**: Eliminates the RCE attack vector entirely — JSON cannot execute arbitrary code on deserialization
- **Interoperability**: Checkpoint files are now human-readable JSON that can be inspected or used by other tools/languages
- **Compatibility**: No Python version or class structure coupling — JSON is stable across versions
- **No new dependencies**: Uses `orjson` which is already a core dependency

### Testing

All existing tests pass (25 checkpoint tests, 9 engine checkpoint tests, 6 force-stop checkpoint tests).

Closes #263