### PR TITLE
fix: support MCP user data dir env

### DIFF
--- a/scrapling/core/ai.py
+++ b/scrapling/core/ai.py
@@ -1,3 +1,4 @@
+from os import environ
 from uuid import uuid4
 from asyncio import gather
 from datetime import datetime, timezone
@@ -33,6 +34,7 @@ from scrapling.core._types import (
 
 SessionType = Literal["dynamic", "stealthy"]
 ScreenshotType = Literal["png", "jpeg"]
+USER_DATA_DIR_ENV = "SCRAPLING_USER_DATA_DIR"
 
 
 class ResponseModel(BaseModel):
@@ -102,6 +104,13 @@ def _normalize_credentials(credentials: Optional[Dict[str, str]]) -> Optional[Tu
         raise ValueError("Credentials dictionary must contain both 'username' and 'password' keys")
 
     return username, password
+
+
+def _apply_mcp_user_data_dir(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    user_data_dir = environ.get(USER_DATA_DIR_ENV)
+    if user_data_dir:
+        kwargs["user_data_dir"] = user_data_dir
+    return kwargs
 
 
 class ScraplingMCPServer:
@@ -205,6 +214,7 @@ class ScraplingMCPServer:
             disable_resources=disable_resources,
             wait_selector_state=wait_selector_state,
         )
+        _apply_mcp_user_data_dir(common_kwargs)
 
         session: Union[AsyncDynamicSession, AsyncStealthySession]
         if session_type == "stealthy":
@@ -637,24 +647,28 @@ class ScraplingMCPServer:
             responses = await gather(*tasks)
         else:
             async with AsyncDynamicSession(
-                wait=wait,
-                proxy=proxy,
-                locale=locale,
-                timeout=timeout,
-                cookies=cookies,
-                cdp_url=cdp_url,
-                headless=headless,
-                block_ads=True,
-                max_pages=len(urls),
-                useragent=useragent,
-                timezone_id=timezone_id,
-                real_chrome=real_chrome,
-                network_idle=network_idle,
-                wait_selector=wait_selector,
-                google_search=google_search,
-                extra_headers=extra_headers,
-                disable_resources=disable_resources,
-                wait_selector_state=wait_selector_state,
+                **_apply_mcp_user_data_dir(
+                    dict(
+                        wait=wait,
+                        proxy=proxy,
+                        locale=locale,
+                        timeout=timeout,
+                        cookies=cookies,
+                        cdp_url=cdp_url,
+                        headless=headless,
+                        block_ads=True,
+                        max_pages=len(urls),
+                        useragent=useragent,
+                        timezone_id=timezone_id,
+                        real_chrome=real_chrome,
+                        network_idle=network_idle,
+                        wait_selector=wait_selector,
+                        google_search=google_search,
+                        extra_headers=extra_headers,
+                        disable_resources=disable_resources,
+                        wait_selector_state=wait_selector_state,
+                    )
+                )
             ) as session:
                 tasks = [session.fetch(url) for url in urls]
                 responses = await gather(*tasks)
@@ -846,28 +860,32 @@ class ScraplingMCPServer:
             responses = await gather(*tasks)
         else:
             async with AsyncStealthySession(
-                wait=wait,
-                proxy=proxy,
-                locale=locale,
-                cdp_url=cdp_url,
-                timeout=timeout,
-                cookies=cookies,
-                headless=headless,
-                block_ads=True,
-                useragent=useragent,
-                timezone_id=timezone_id,
-                real_chrome=real_chrome,
-                hide_canvas=hide_canvas,
-                allow_webgl=allow_webgl,
-                network_idle=network_idle,
-                block_webrtc=block_webrtc,
-                wait_selector=wait_selector,
-                google_search=google_search,
-                extra_headers=extra_headers,
-                additional_args=additional_args,
-                solve_cloudflare=solve_cloudflare,
-                disable_resources=disable_resources,
-                wait_selector_state=wait_selector_state,
+                **_apply_mcp_user_data_dir(
+                    dict(
+                        wait=wait,
+                        proxy=proxy,
+                        locale=locale,
+                        cdp_url=cdp_url,
+                        timeout=timeout,
+                        cookies=cookies,
+                        headless=headless,
+                        block_ads=True,
+                        useragent=useragent,
+                        timezone_id=timezone_id,
+                        real_chrome=real_chrome,
+                        hide_canvas=hide_canvas,
+                        allow_webgl=allow_webgl,
+                        network_idle=network_idle,
+                        block_webrtc=block_webrtc,
+                        wait_selector=wait_selector,
+                        google_search=google_search,
+                        extra_headers=extra_headers,
+                        additional_args=additional_args,
+                        solve_cloudflare=solve_cloudflare,
+                        disable_resources=disable_resources,
+                        wait_selector_state=wait_selector_state,
+                    )
+                )
             ) as session:
                 tasks = [session.fetch(url) for url in urls]
                 responses = await gather(*tasks)

--- a/tests/ai/test_ai_mcp.py
+++ b/tests/ai/test_ai_mcp.py
@@ -8,6 +8,7 @@ import pytest
 import pytest_httpbin
 from mcp.types import ImageContent, TextContent
 
+import scrapling.core.ai as ai_module
 from scrapling.core.ai import (
     ScraplingMCPServer,
     ResponseModel,
@@ -202,6 +203,38 @@ class TestSessionManagement:
             await server.open_session(session_type="dynamic", session_id="dupe", headless=True)
 
         await server.close_session("dupe")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("session_type", "session_class_name"),
+        [("dynamic", "AsyncDynamicSession"), ("stealthy", "AsyncStealthySession")],
+    )
+    async def test_open_session_uses_env_user_data_dir(
+        self, server, monkeypatch, tmp_path, session_type, session_class_name
+    ):
+        """Browser sessions use SCRAPLING_USER_DATA_DIR when it is set."""
+        captured_kwargs = {}
+
+        class FakeSession:
+            _is_alive = True
+
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+            async def start(self):
+                pass
+
+            async def close(self):
+                self._is_alive = False
+
+        user_data_dir = str(tmp_path / "profile")
+        monkeypatch.setenv("SCRAPLING_USER_DATA_DIR", user_data_dir)
+        monkeypatch.setattr(ai_module, session_class_name, FakeSession)
+
+        opened = await server.open_session(session_type=session_type, headless=True)
+
+        assert captured_kwargs["user_data_dir"] == user_data_dir
+        await server.close_session(opened.session_id)
 
 
 def _png_height(data: bytes) -> int:


### PR DESCRIPTION
## Summary
- read `SCRAPLING_USER_DATA_DIR` in the MCP server
- pass that profile path into dynamic and stealthy browser sessions created by `open_session`, `fetch`, and `stealthy_fetch`
- add unit coverage with fake browser sessions so the env plumbing is tested without launching Playwright

Fixes #269.

## Tests
- `py -3 -m pytest tests/ai/test_ai_mcp.py -q -k user_data_dir`
- `py -3 -m pytest tests/ai/test_ai_mcp.py -q`
- `py -3 -m compileall -q scrapling/core/ai.py tests/ai/test_ai_mcp.py`
- `git diff --check`