### PR TITLE
Fix: cdp connections spawn isolated contexts instead of reusing existing profiles

### DIFF
--- a/scrapling/engines/_browsers/_controllers.py
+++ b/scrapling/engines/_browsers/_controllers.py
@@ -78,7 +78,10 @@ class DynamicSession(SyncSession, DynamicSessionMixin):
                 if self._config.cdp_url:  # pragma: no cover
                     self.browser = self.playwright.chromium.connect_over_cdp(endpoint_url=self._config.cdp_url)
                     if not self._config.proxy_rotator and self.browser:
-                        self.context = self.browser.new_context(**self._context_options)
+                        if self.browser.contexts:
+                            self.context = self.browser.contexts[0]
+                        else:
+                            self.context = self.browser.new_context(**self._context_options)
                 elif self._config.proxy_rotator:
                     self.browser = self.playwright.chromium.launch(**self._browser_options)
                 else:
@@ -266,7 +269,10 @@ class AsyncDynamicSession(AsyncSession, DynamicSessionMixin):
                 if self._config.cdp_url:
                     self.browser = await self.playwright.chromium.connect_over_cdp(endpoint_url=self._config.cdp_url)
                     if not self._config.proxy_rotator and self.browser:
-                        self.context = await self.browser.new_context(**self._context_options)
+                        if self.browser.contexts:
+                            self.context = self.browser.contexts[0]
+                        else:
+                            self.context = await self.browser.new_context(**self._context_options)
                 elif self._config.proxy_rotator:
                     self.browser = await self.playwright.chromium.launch(**self._browser_options)
                 else:

--- a/scrapling/engines/_browsers/_stealth.py
+++ b/scrapling/engines/_browsers/_stealth.py
@@ -83,7 +83,10 @@ class StealthySession(SyncSession, StealthySessionMixin):
                     self.browser = self.playwright.chromium.connect_over_cdp(endpoint_url=self._config.cdp_url)
                     if not self._config.proxy_rotator:
                         assert self.browser is not None
-                        self.context = self.browser.new_context(**self._context_options)
+                        if self.browser.contexts:
+                            self.context = self.browser.contexts[0]
+                        else:
+                            self.context = self.browser.new_context(**self._context_options)
                 elif self._config.proxy_rotator:
                     self.browser = self.playwright.chromium.launch(**self._browser_options)
                 else:
@@ -358,7 +361,10 @@ class AsyncStealthySession(AsyncSession, StealthySessionMixin):
                     self.browser = await self.playwright.chromium.connect_over_cdp(endpoint_url=self._config.cdp_url)
                     if not self._config.proxy_rotator:
                         assert self.browser is not None
-                        self.context = await self.browser.new_context(**self._context_options)
+                        if self.browser.contexts:
+                            self.context = self.browser.contexts[0]
+                        else:
+                            self.context = await self.browser.new_context(**self._context_options)
                 elif self._config.proxy_rotator:
                     self.browser = await self.playwright.chromium.launch(**self._browser_options)
                 else:


### PR DESCRIPTION
### What does this PR do?
This PR modifies the default behavior of `cdp_url` connections across all Fetcher variants (Sync and Async, Dynamic and Stealthy).

Currently, when passing a `cdp_url` to connect to an existing, headful Chrome browser, Scrapling unconditionally calls `browser.new_context()`. Because of how Playwright operates, this generates a completely isolated, incognito-like browsing context. As a result, the user's active logins, installed extensions, and session cookies from their main profile are not accessible to the Fetcher.

This PR checks if `browser.contexts` exists upon a successful CDP connection. If the default context exists, it assigns it to `self.context` instead of spawning a new one.

### Why is this needed?
The primary use case for connecting to an active browser via a debug port (`cdp_url`) is to leverage the existing, authenticated state of that browser (e.g., bypassing logins or utilizing active extensions). Spawning an isolated context defeats the purpose of connecting to a pre-configured user-data directory.

### Impact
* `cdp_url` connections will now inherit the browser's active tabs, cookies, and extensions.
* Proxy rotation and standard headless/headful launches are completely unaffected by this change.