### PR TITLE
sec(mcp): harden HTTP transport with bearer auth and URL guard

### DIFF
--- a/scrapling/cli.py
+++ b/scrapling/cli.py
@@ -150,14 +150,50 @@ def install(force):  # pragma: no cover
 @option(
     "--host",
     type=str,
-    default="0.0.0.0",
-    help="The host to use if streamable-http transport is enabled (Default: '0.0.0.0')",
+    default="127.0.0.1",
+    help="Host to bind when --http is set. Defaults to loopback. Use --bind-all to listen on all interfaces.",
+)
+@option(
+    "--bind-all",
+    is_flag=True,
+    default=False,
+    help="Allow binding the HTTP MCP transport to all interfaces (0.0.0.0). Required when exposing the server beyond localhost.",
 )
 @option(
     "--port", type=int, default=8000, help="The port to use if streamable-http transport is enabled (Default: 8000)"
 )
-def mcp(http, host, port):
+def mcp(http, host, port, bind_all):
+    from click import UsageError, secho
+
     from scrapling.core.ai import ScraplingMCPServer
+    from scrapling.core._url_guard import UnsafeURLError
+
+    _ALL_INTERFACE_HOSTS = {"0.0.0.0", "::", "*"}
+
+    if http:
+        if bind_all:
+            host = "0.0.0.0"
+        if host in _ALL_INTERFACE_HOSTS and not bind_all:
+            raise UsageError(
+                "Refusing to bind HTTP MCP transport to all interfaces without --bind-all. "
+                "Use --host 127.0.0.1 (default) or pass --bind-all explicitly."
+            )
+        try:
+            from scrapling.core._url_guard import require_http_token
+
+            require_http_token()
+        except UnsafeURLError as e:
+            raise UsageError(str(e))
+        if bind_all:
+            secho(
+                "WARNING: HTTP MCP transport is binding to 0.0.0.0. The server will be reachable "
+                "from every network this machine is connected to. Per-request Bearer auth using "
+                "SCRAPLING_MCP_TOKEN is enforced, but treat the token as a shared secret and "
+                "consider terminating TLS in a reverse proxy before exposing this beyond a "
+                "trusted network.",
+                fg="yellow",
+                err=True,
+            )
 
     server = ScraplingMCPServer()
     server.serve(http, host, port)

--- a/scrapling/core/_mcp_auth.py
+++ b/scrapling/core/_mcp_auth.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Request-level Bearer token verification for the HTTP MCP transport.
+
+FastMCP's ``streamable-http`` transport accepts a ``TokenVerifier`` whose
+``verify_token`` coroutine is invoked by the bundled ``BearerAuthBackend``
+for every incoming request that carries an ``Authorization: Bearer <...>``
+header. ``RequireAuthMiddleware`` rejects requests that arrive without a
+verified user with HTTP 401. We plug a static, constant-time verifier in
+front of that machinery so the value of ``SCRAPLING_MCP_TOKEN`` is checked
+on every request rather than only at process startup.
+"""
+from __future__ import annotations
+
+import hmac
+from typing import Optional
+
+
+def _to_bytes(value: str) -> Optional[bytes]:
+    if not isinstance(value, str):
+        return None
+    try:
+        return value.encode("utf-8")
+    except UnicodeEncodeError:  # pragma: no cover - defensive
+        return None
+
+
+class StaticBearerTokenVerifier:
+    """Verifier that accepts exactly one shared-secret bearer token.
+
+    The expected token is captured at construction time. Comparison is done
+    with :func:`hmac.compare_digest` to avoid leaking information through
+    timing side channels.
+    """
+
+    def __init__(self, expected_token: str):
+        token = (expected_token or "").strip()
+        if not token:
+            raise ValueError("StaticBearerTokenVerifier requires a non-empty token.")
+        self._expected = token.encode("utf-8")
+        self._client_id = "scrapling-mcp"
+
+    async def verify_token(self, token: str):
+        """Return an :class:`AccessToken` on a match, ``None`` otherwise.
+
+        The MCP ``BearerAuthBackend`` treats ``None`` as an authentication
+        failure, which is then turned into a 401 by ``RequireAuthMiddleware``.
+        """
+        from mcp.server.auth.provider import AccessToken
+
+        candidate = _to_bytes(token)
+        if candidate is None:
+            return None
+        # Constant-time comparison; lengths may differ but compare_digest
+        # handles that without an early-exit length branch.
+        if not hmac.compare_digest(self._expected, candidate):
+            return None
+        return AccessToken(
+            token=token,
+            client_id=self._client_id,
+            scopes=[],
+            expires_at=None,
+        )
+
+
+def build_http_auth(token: str, port: int):
+    """Build the ``(auth_settings, verifier)`` pair for FastMCP HTTP mode.
+
+    ``AuthSettings`` requires ``issuer_url`` and ``resource_server_url``.
+    They are only used as identifiers in protected-resource metadata; we
+    synthesize them from the bind port so the operator does not have to
+    configure an OAuth issuer for what is, semantically, a static shared
+    secret deployment.
+    """
+    from mcp.server.auth.settings import AuthSettings
+    from pydantic import AnyHttpUrl
+
+    base_url = AnyHttpUrl(f"http://127.0.0.1:{int(port)}")
+    settings = AuthSettings(
+        issuer_url=base_url,
+        resource_server_url=base_url,
+        required_scopes=[],
+    )
+    return settings, StaticBearerTokenVerifier(token)

--- a/scrapling/core/_url_guard.py
+++ b/scrapling/core/_url_guard.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Internal URL guard used by the MCP server tools.
+
+Refuses non-HTTP schemes and SSRF-prone targets (loopback, private,
+link-local, multicast, reserved, unspecified IPs). Optional allowlist
+via ``SCRAPLING_MCP_ALLOWLIST``. A development escape hatch
+(``SCRAPLING_MCP_ALLOW_LOCAL=1``) bypasses the IP-class checks; it is
+intended only for local testing and is documented as such.
+"""
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from typing import FrozenSet, Iterable, Optional, Tuple
+from urllib.parse import urlparse
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_ALLOWLIST_ENV = "SCRAPLING_MCP_ALLOWLIST"
+_ALLOW_LOCAL_ENV = "SCRAPLING_MCP_ALLOW_LOCAL"
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL fails MCP safety validation."""
+
+
+def _ip_block_reason(ip: ipaddress._BaseAddress) -> Optional[str]:
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_link_local:
+        return "link-local"
+    if ip.is_multicast:
+        return "multicast"
+    if ip.is_unspecified:
+        return "unspecified"
+    if ip.is_private:
+        return "private"
+    if ip.is_reserved:
+        return "reserved"
+    return None
+
+
+def _load_allowlist() -> Optional[FrozenSet[str]]:
+    raw = os.environ.get(_ALLOWLIST_ENV, "").strip()
+    if not raw:
+        return None
+    items = {h.strip().lower().lstrip(".") for h in raw.split(",") if h.strip()}
+    return frozenset(items) if items else None
+
+
+def _hostname_in_allowlist(hostname: str, allowlist: Iterable[str]) -> bool:
+    h = hostname.lower()
+    for entry in allowlist:
+        if h == entry or h.endswith("." + entry):
+            return True
+    return False
+
+
+def _allow_local() -> bool:
+    return os.environ.get(_ALLOW_LOCAL_ENV, "").strip() in {"1", "true", "yes", "on"}
+
+
+def _try_parse_ip(value: str) -> Optional[ipaddress._BaseAddress]:
+    candidate = value
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    try:
+        return ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+
+
+def _check_ip(
+    ip: ipaddress._BaseAddress, hostname: str, *, original: Optional[str] = None
+) -> None:
+    reason = _ip_block_reason(ip)
+    if reason is None:
+        return
+    detail = f"{hostname}" if original is None or original == hostname else f"{hostname} ({original})"
+    raise UnsafeURLError(f"Host '{detail}' resolves to a {reason} address; refused.")
+
+
+def validate_url(
+    url: str,
+    *,
+    allowlist: Optional[Iterable[str]] = None,
+    allow_local: Optional[bool] = None,
+) -> None:
+    """Validate a URL for MCP-driven outbound fetch.
+
+    :param url: The URL to validate.
+    :param allowlist: Optional iterable of allowed hostnames. If ``None``,
+        the value of ``SCRAPLING_MCP_ALLOWLIST`` is used. When effectively
+        empty, no allowlist is enforced.
+    :param allow_local: Override for the ``SCRAPLING_MCP_ALLOW_LOCAL`` env
+        var. Bypasses the IP-class blocks (still enforces scheme and
+        allowlist). Intended for local development/tests only.
+    :raises UnsafeURLError: on any rule violation.
+    """
+    if not isinstance(url, str) or not url:
+        raise UnsafeURLError("URL must be a non-empty string.")
+
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise UnsafeURLError(
+            f"URL scheme '{scheme or '<empty>'}' is not allowed; only http/https are permitted."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UnsafeURLError("URL must include a hostname.")
+
+    effective_allowlist = allowlist if allowlist is not None else _load_allowlist()
+    if effective_allowlist is not None and not _hostname_in_allowlist(hostname, effective_allowlist):
+        raise UnsafeURLError(f"Host '{hostname}' is not in the configured allowlist.")
+
+    bypass_ip_checks = allow_local if allow_local is not None else _allow_local()
+    if bypass_ip_checks:
+        return
+
+    direct_ip = _try_parse_ip(hostname)
+    if direct_ip is not None:
+        _check_ip(direct_ip, hostname)
+        return
+
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise UnsafeURLError(f"Host '{hostname}' could not be resolved: {e}")
+
+    seen = set()
+    for info in infos:
+        sockaddr = info[4]
+        addr = sockaddr[0]
+        if addr in seen:
+            continue
+        seen.add(addr)
+        resolved = _try_parse_ip(addr)
+        if resolved is None:
+            continue
+        _check_ip(resolved, hostname, original=addr)
+
+
+def require_http_token() -> str:
+    """Return the configured HTTP MCP token or raise ``UnsafeURLError``.
+
+    Used both as a startup gate and as the shared secret that the HTTP
+    MCP transport's per-request Bearer auth (see
+    :mod:`scrapling.core._mcp_auth`) compares incoming
+    ``Authorization`` headers against.
+    """
+    token = os.environ.get("SCRAPLING_MCP_TOKEN", "").strip()
+    if not token:
+        raise UnsafeURLError(
+            "HTTP MCP transport requires SCRAPLING_MCP_TOKEN to be set in the environment."
+        )
+    return token

--- a/scrapling/core/ai.py
+++ b/scrapling/core/ai.py
@@ -7,6 +7,11 @@ from mcp.server.fastmcp import FastMCP, Image
 from mcp.types import ImageContent, TextContent
 from pydantic import BaseModel, Field
 
+from scrapling.core._url_guard import (
+    UnsafeURLError,
+    require_http_token,
+    validate_url as _validate_mcp_url,
+)
 from scrapling.core.shell import Convertor
 from scrapling.engines.toolbelt.custom import Response as _ScraplingResponse
 from scrapling.engines.static import ImpersonateType
@@ -88,6 +93,18 @@ def _translate_response(
         )
     )
     return ResponseModel(status=page.status, content=content, url=page.url)
+
+
+def _guard_urls(urls) -> None:
+    """Validate every URL handed to an MCP tool. Raises ``UnsafeURLError``.
+
+    ``urls`` may be a single string or any iterable of strings.
+    """
+    if isinstance(urls, str):
+        _validate_mcp_url(urls)
+        return
+    for u in urls:
+        _validate_mcp_url(u)
 
 
 def _normalize_credentials(credentials: Optional[Dict[str, str]]) -> Optional[Tuple[str, str]]:
@@ -292,6 +309,7 @@ class ScraplingMCPServer:
         if quality is not None and image_type != "jpeg":
             raise ValueError("'quality' is only valid when 'image_type' is 'jpeg'.")
 
+        _guard_urls(url)
         entry = self._get_session(session_id, expected_type=None)
 
         screenshot_kwargs: Dict[str, Any] = {"type": image_type, "full_page": full_page}
@@ -450,6 +468,7 @@ class ScraplingMCPServer:
         :param http3: Whether to use HTTP3. Defaults to False. It might be problematic if used it with `impersonate`.
         :param stealthy_headers: If enabled (default), it creates and adds real browser headers. It also sets a Google referer header.
         """
+        _guard_urls(urls)
         normalized_proxy_auth = _normalize_credentials(proxy_auth)
         normalized_auth = _normalize_credentials(auth)
 
@@ -617,6 +636,7 @@ class ScraplingMCPServer:
         :param proxy: The proxy to be used with requests, it can be a string or a dictionary with the keys 'server', 'username', and 'password' only.
         :param session_id: Optional session ID from open_session. If provided, reuses the existing browser session instead of creating a new one.
         """
+        _guard_urls(urls)
         if session_id:
             entry = self._get_session(session_id, "dynamic")
             tasks = [
@@ -825,6 +845,7 @@ class ScraplingMCPServer:
         :param additional_args: Additional arguments to be passed to Playwright's context as additional settings, and it takes higher priority than Scrapling's settings.
         :param session_id: Optional session ID from open_session. If provided, reuses the existing browser session instead of creating a new one.
         """
+        _guard_urls(urls)
         if session_id:
             entry = self._get_session(session_id, "stealthy")
             tasks = [
@@ -875,8 +896,32 @@ class ScraplingMCPServer:
         return [_translate_response(page, extraction_type, css_selector, main_content_only) for page in responses]
 
     def serve(self, http: bool, host: str, port: int):
-        """Serve the MCP server."""
-        server = FastMCP(name="Scrapling", host=host, port=port)
+        """Serve the MCP server.
+
+        Security notes:
+          * HTTP transport refuses to start unless ``SCRAPLING_MCP_TOKEN``
+            is set, and that same token is required, per request, in an
+            ``Authorization: Bearer <token>`` header. Requests without a
+            bearer token receive 401; requests with a wrong token receive
+            401. Comparison is constant-time via ``hmac.compare_digest``.
+          * stdio transport requires no token and applies no auth.
+          * Tool methods themselves validate URLs (``_guard_urls``) and
+            consult the optional ``SCRAPLING_MCP_ALLOWLIST``.
+        """
+        if http:
+            from scrapling.core._mcp_auth import build_http_auth
+
+            token = require_http_token()
+            auth_settings, token_verifier = build_http_auth(token, port)
+            server = FastMCP(
+                name="Scrapling",
+                host=host,
+                port=port,
+                auth=auth_settings,
+                token_verifier=token_verifier,
+            )
+        else:
+            server = FastMCP(name="Scrapling", host=host, port=port)
         # Session management tools
         server.add_tool(self.open_session, title="open_session", structured_output=True)
         server.add_tool(self.close_session, title="close_session", structured_output=True)

--- a/tests/ai/conftest.py
+++ b/tests/ai/conftest.py
@@ -1,0 +1,14 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _allow_local_mcp_targets(monkeypatch):
+    """The existing MCP test suite uses pytest_httpbin which serves on
+    localhost. The MCP URL guard otherwise blocks loopback targets, so we
+    set the documented dev-only escape hatch for these tests.
+    """
+    monkeypatch.setenv("SCRAPLING_MCP_ALLOW_LOCAL", "1")
+    monkeypatch.delenv("SCRAPLING_MCP_ALLOWLIST", raising=False)
+    yield

--- a/tests/ai/test_mcp_http_auth.py
+++ b/tests/ai/test_mcp_http_auth.py
@@ -1,0 +1,192 @@
+"""Tests for the request-level Bearer auth on the HTTP MCP transport."""
+from __future__ import annotations
+
+import pytest
+
+from scrapling.core._mcp_auth import StaticBearerTokenVerifier, build_http_auth
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in ("SCRAPLING_MCP_TOKEN", "SCRAPLING_MCP_ALLOWLIST", "SCRAPLING_MCP_ALLOW_LOCAL"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+class TestStaticBearerTokenVerifier:
+    def test_construction_rejects_empty_token(self):
+        with pytest.raises(ValueError):
+            StaticBearerTokenVerifier("")
+
+    def test_construction_rejects_whitespace_token(self):
+        with pytest.raises(ValueError):
+            StaticBearerTokenVerifier("   ")
+
+    @pytest.mark.asyncio
+    async def test_correct_token_returns_access_token(self):
+        verifier = StaticBearerTokenVerifier("s3cret")
+        result = await verifier.verify_token("s3cret")
+        assert result is not None
+        assert result.token == "s3cret"
+        assert result.scopes == []
+        assert result.client_id == "scrapling-mcp"
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_returns_none(self):
+        verifier = StaticBearerTokenVerifier("s3cret")
+        assert await verifier.verify_token("not-the-token") is None
+
+    @pytest.mark.asyncio
+    async def test_empty_token_returns_none(self):
+        verifier = StaticBearerTokenVerifier("s3cret")
+        assert await verifier.verify_token("") is None
+
+    @pytest.mark.asyncio
+    async def test_non_string_token_returns_none(self):
+        verifier = StaticBearerTokenVerifier("s3cret")
+        # The MCP protocol always passes str, but verify defensive handling.
+        assert await verifier.verify_token(None) is None  # type: ignore[arg-type]
+        assert await verifier.verify_token(12345) is None  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_prefix_match_is_rejected(self):
+        # Constant-time compare is not a prefix match; it must be exact.
+        verifier = StaticBearerTokenVerifier("s3cret")
+        assert await verifier.verify_token("s3cre") is None
+        assert await verifier.verify_token("s3cret-extra") is None
+
+
+class TestBuildHttpAuth:
+    def test_returns_settings_and_verifier(self):
+        settings, verifier = build_http_auth("token-abc", port=8123)
+        # Settings carry the synthetic identifier URLs FastMCP requires.
+        assert str(settings.issuer_url).startswith("http://127.0.0.1:8123")
+        assert str(settings.resource_server_url).startswith("http://127.0.0.1:8123")
+        assert settings.required_scopes == []
+        assert isinstance(verifier, StaticBearerTokenVerifier)
+
+
+class TestStreamableHttpAuthIntegration:
+    """Drive the actual FastMCP streamable_http app and confirm Bearer auth.
+
+    The auth check sits at the route level via ``RequireAuthMiddleware``,
+    so a missing or wrong token must produce HTTP 401 *before* the body
+    is parsed by the MCP layer. A valid token must NOT produce 401 (the
+    transport may still reject the request body for other reasons; we
+    only assert that auth no longer rejects it).
+    """
+
+    @pytest.fixture
+    def token(self):
+        return "shared-secret-xyz"
+
+    @pytest.fixture
+    def app(self, token):
+        from mcp.server.fastmcp import FastMCP
+
+        auth_settings, verifier = build_http_auth(token, port=8000)
+        # host="0.0.0.0" so FastMCP does not auto-enable DNS rebinding
+        # protection (which would otherwise reject TestClient's
+        # "testserver" Host header).
+        server = FastMCP(
+            name="auth-test",
+            host="0.0.0.0",
+            port=8000,
+            auth=auth_settings,
+            token_verifier=verifier,
+        )
+        return server.streamable_http_app()
+
+    @pytest.fixture
+    def client(self, app):
+        from starlette.testclient import TestClient
+
+        return TestClient(app)
+
+    def test_missing_authorization_header_yields_401(self, client):
+        response = client.post("/mcp", json={"jsonrpc": "2.0", "method": "ping", "id": 1})
+        assert response.status_code == 401
+
+    def test_non_bearer_authorization_header_yields_401(self, client):
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "ping", "id": 1},
+            headers={"Authorization": "Basic dXNlcjpwYXNz"},
+        )
+        assert response.status_code == 401
+
+    def test_wrong_bearer_token_yields_401(self, client):
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "ping", "id": 1},
+            headers={"Authorization": "Bearer not-the-real-token"},
+        )
+        assert response.status_code == 401
+
+    def test_empty_bearer_token_yields_401(self, client):
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "ping", "id": 1},
+            headers={"Authorization": "Bearer "},
+        )
+        assert response.status_code == 401
+
+    def test_correct_bearer_token_passes_auth(self, app, token):
+        # The streamable HTTP session manager needs the Starlette lifespan
+        # to be active (it owns a task group spun up at startup), so we
+        # drive the app via TestClient as a context manager.
+        from starlette.testclient import TestClient
+
+        with TestClient(app) as client:
+            response = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "ping", "id": 1},
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/json, text/event-stream",
+                    "Content-Type": "application/json",
+                },
+            )
+        # The MCP layer may still reject the body shape (e.g., 400/406),
+        # but auth is what this test is about.
+        assert response.status_code != 401
+
+
+class TestServeWiresAuthForHttp:
+    """The high-level ``ScraplingMCPServer.serve`` path must hand FastMCP
+    both ``auth`` settings and a token verifier when ``http=True``, and
+    must NOT do so for stdio.
+    """
+
+    def test_http_serve_constructs_fastmcp_with_auth(self, monkeypatch):
+        from unittest.mock import MagicMock, patch
+
+        from scrapling.core.ai import ScraplingMCPServer
+        from scrapling.core._mcp_auth import StaticBearerTokenVerifier
+
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "abc")
+        with patch("scrapling.core.ai.FastMCP") as fastmcp_cls:
+            instance = MagicMock()
+            fastmcp_cls.return_value = instance
+            ScraplingMCPServer().serve(http=True, host="127.0.0.1", port=8000)
+
+        fastmcp_cls.assert_called_once()
+        kwargs = fastmcp_cls.call_args.kwargs
+        assert kwargs.get("auth") is not None
+        assert isinstance(kwargs.get("token_verifier"), StaticBearerTokenVerifier)
+
+    def test_stdio_serve_does_not_pass_auth(self, monkeypatch):
+        from unittest.mock import MagicMock, patch
+
+        from scrapling.core.ai import ScraplingMCPServer
+
+        # No SCRAPLING_MCP_TOKEN set; stdio must not require it.
+        with patch("scrapling.core.ai.FastMCP") as fastmcp_cls:
+            instance = MagicMock()
+            fastmcp_cls.return_value = instance
+            ScraplingMCPServer().serve(http=False, host="127.0.0.1", port=8000)
+
+        fastmcp_cls.assert_called_once()
+        kwargs = fastmcp_cls.call_args.kwargs
+        assert "auth" not in kwargs or kwargs.get("auth") is None
+        assert "token_verifier" not in kwargs or kwargs.get("token_verifier") is None

--- a/tests/ai/test_url_guard.py
+++ b/tests/ai/test_url_guard.py
@@ -1,0 +1,182 @@
+import socket
+
+import pytest
+
+from scrapling.core._url_guard import (
+    UnsafeURLError,
+    require_http_token,
+    validate_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Each test starts with no MCP env vars set."""
+    for var in ("SCRAPLING_MCP_ALLOW_LOCAL", "SCRAPLING_MCP_ALLOWLIST", "SCRAPLING_MCP_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def _addrinfo_for(*addresses):
+    """Build a socket.getaddrinfo-style return value for the given IPs."""
+
+    def _fake(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (addr, 0)) for addr in addresses]
+
+    return _fake
+
+
+class TestSchemeRules:
+    def test_rejects_file_scheme(self):
+        with pytest.raises(UnsafeURLError):
+            validate_url("file:///etc/passwd")
+
+    def test_rejects_ftp_scheme(self):
+        with pytest.raises(UnsafeURLError):
+            validate_url("ftp://example.com/foo")
+
+    def test_rejects_gopher_scheme(self):
+        with pytest.raises(UnsafeURLError):
+            validate_url("gopher://example.com/")
+
+    def test_rejects_data_scheme(self):
+        with pytest.raises(UnsafeURLError):
+            validate_url("data:text/html,<script>alert(1)</script>")
+
+    def test_rejects_empty_url(self):
+        with pytest.raises(UnsafeURLError):
+            validate_url("")
+
+    def test_rejects_url_without_host(self):
+        with pytest.raises(UnsafeURLError):
+            validate_url("http://")
+
+
+class TestIPLiteralRules:
+    def test_rejects_loopback_127(self):
+        with pytest.raises(UnsafeURLError, match="loopback"):
+            validate_url("http://127.0.0.1/")
+
+    def test_rejects_loopback_localhost_via_dns(self, monkeypatch):
+        # localhost is a hostname; resolution should yield 127.0.0.1
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("127.0.0.1"))
+        with pytest.raises(UnsafeURLError, match="loopback"):
+            validate_url("http://localhost/")
+
+    def test_rejects_link_local_metadata(self):
+        with pytest.raises(UnsafeURLError, match="link-local"):
+            validate_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_rejects_private_10(self):
+        with pytest.raises(UnsafeURLError, match="private"):
+            validate_url("http://10.0.0.1/")
+
+    def test_rejects_private_192_168(self):
+        with pytest.raises(UnsafeURLError, match="private"):
+            validate_url("http://192.168.1.1/")
+
+    def test_rejects_private_172_16(self):
+        with pytest.raises(UnsafeURLError, match="private"):
+            validate_url("http://172.16.0.1/")
+
+    def test_rejects_unspecified(self):
+        with pytest.raises(UnsafeURLError):
+            validate_url("http://0.0.0.0/")
+
+    def test_rejects_ipv6_loopback(self):
+        with pytest.raises(UnsafeURLError, match="loopback"):
+            validate_url("http://[::1]/")
+
+    def test_rejects_ipv6_link_local(self):
+        with pytest.raises(UnsafeURLError, match="link-local"):
+            validate_url("http://[fe80::1]/")
+
+
+class TestDNSResolution:
+    def test_rejects_when_dns_resolves_to_private_ip(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("10.0.0.42"))
+        with pytest.raises(UnsafeURLError, match="private"):
+            validate_url("http://example.com/")
+
+    def test_accepts_when_dns_resolves_to_public_ip(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("93.184.216.34"))
+        validate_url("http://example.com/")  # no exception
+
+    def test_rejects_when_dns_fails(self, monkeypatch):
+        def _raise(*a, **kw):
+            raise socket.gaierror(-2, "Name or service not known")
+
+        monkeypatch.setattr(socket, "getaddrinfo", _raise)
+        with pytest.raises(UnsafeURLError, match="could not be resolved"):
+            validate_url("http://this-host-does-not-resolve.invalid/")
+
+    def test_rejects_when_any_resolved_address_is_private(self, monkeypatch):
+        # Multi-A record where one entry is public and another is private.
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("93.184.216.34", "10.0.0.5"))
+        with pytest.raises(UnsafeURLError, match="private"):
+            validate_url("http://example.com/")
+
+
+class TestAllowlist:
+    def test_allowlist_rejects_other_domain(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("93.184.216.34"))
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOWLIST", "internal.example")
+        with pytest.raises(UnsafeURLError, match="allowlist"):
+            validate_url("http://example.com/")
+
+    def test_allowlist_accepts_exact_match(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("93.184.216.34"))
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOWLIST", "example.com")
+        validate_url("http://example.com/")
+
+    def test_allowlist_accepts_subdomain(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("93.184.216.34"))
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOWLIST", "example.com")
+        validate_url("http://api.example.com/v1")
+
+    def test_allowlist_does_not_match_partial_suffix(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("93.184.216.34"))
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOWLIST", "example.com")
+        with pytest.raises(UnsafeURLError, match="allowlist"):
+            validate_url("http://notexample.com/")
+
+    def test_allowlist_with_multiple_entries(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _addrinfo_for("93.184.216.34"))
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOWLIST", "foo.test, example.com , bar.test")
+        validate_url("http://example.com/")
+
+
+class TestAllowLocalEscapeHatch:
+    def test_env_var_bypasses_ip_blocks(self, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOW_LOCAL", "1")
+        validate_url("http://127.0.0.1/")
+        validate_url("http://10.0.0.1/")
+
+    def test_explicit_param_bypasses_ip_blocks(self):
+        validate_url("http://127.0.0.1/", allow_local=True)
+
+    def test_allow_local_still_enforces_scheme(self, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOW_LOCAL", "1")
+        with pytest.raises(UnsafeURLError):
+            validate_url("file:///etc/passwd")
+
+    def test_allow_local_still_enforces_allowlist(self, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOW_LOCAL", "1")
+        monkeypatch.setenv("SCRAPLING_MCP_ALLOWLIST", "internal.test")
+        with pytest.raises(UnsafeURLError, match="allowlist"):
+            validate_url("http://127.0.0.1/")
+
+
+class TestRequireHttpToken:
+    def test_raises_when_token_missing(self):
+        with pytest.raises(UnsafeURLError, match="SCRAPLING_MCP_TOKEN"):
+            require_http_token()
+
+    def test_returns_token_when_set(self, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "secret-value")
+        assert require_http_token() == "secret-value"
+
+    def test_raises_when_token_blank(self, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "   ")
+        with pytest.raises(UnsafeURLError):
+            require_http_token()

--- a/tests/cli/test_mcp_cli.py
+++ b/tests/cli/test_mcp_cli.py
@@ -1,0 +1,132 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+# The mcp command imports scrapling.core.ai lazily inside the callback;
+# import it here so that ``patch('scrapling.core.ai.ScraplingMCPServer')``
+# can resolve the attribute path at patch-time.
+import scrapling.core.ai  # noqa: F401
+from scrapling.cli import mcp
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in ("SCRAPLING_MCP_TOKEN", "SCRAPLING_MCP_ALLOWLIST", "SCRAPLING_MCP_ALLOW_LOCAL"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _patched_server():
+    """Patch ScraplingMCPServer at the import site so we never start a real server."""
+    return patch("scrapling.core.ai.ScraplingMCPServer")
+
+
+class TestStdioMode:
+    def test_stdio_default_runs_without_token(self, runner):
+        with _patched_server() as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            result = runner.invoke(mcp, [])
+            assert result.exit_code == 0, result.output
+            mock_instance.serve.assert_called_once()
+            args, kwargs = mock_instance.serve.call_args
+            http_arg = args[0] if args else kwargs["http"]
+            assert http_arg is False
+
+    def test_stdio_does_not_warn_about_bind_all(self, runner):
+        with _patched_server() as mock_cls:
+            mock_cls.return_value = MagicMock()
+            result = runner.invoke(mcp, [])
+            assert "0.0.0.0" not in (result.output or "")
+
+
+class TestHttpDefaultHost:
+    def test_default_host_is_loopback_when_http(self, runner, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "secret")
+        with _patched_server() as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            result = runner.invoke(mcp, ["--http"])
+            assert result.exit_code == 0, result.output
+            args, kwargs = mock_instance.serve.call_args
+            host = args[1] if len(args) >= 2 else kwargs["host"]
+            assert host == "127.0.0.1"
+
+    def test_explicit_host_is_passed_through(self, runner, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "secret")
+        with _patched_server() as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            result = runner.invoke(mcp, ["--http", "--host", "127.0.0.5"])
+            assert result.exit_code == 0, result.output
+            args, kwargs = mock_instance.serve.call_args
+            host = args[1] if len(args) >= 2 else kwargs["host"]
+            assert host == "127.0.0.5"
+
+
+class TestBindAllGate:
+    def test_zero_zero_without_bind_all_is_rejected(self, runner, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "secret")
+        with _patched_server() as mock_cls:
+            mock_cls.return_value = MagicMock()
+            result = runner.invoke(mcp, ["--http", "--host", "0.0.0.0"])
+            assert result.exit_code != 0
+            assert "bind-all" in (result.output or "").lower()
+
+    def test_double_colon_without_bind_all_is_rejected(self, runner, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "secret")
+        with _patched_server() as mock_cls:
+            mock_cls.return_value = MagicMock()
+            result = runner.invoke(mcp, ["--http", "--host", "::"])
+            assert result.exit_code != 0
+
+    def test_bind_all_yields_zero_zero(self, runner, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "secret")
+        with _patched_server() as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            result = runner.invoke(mcp, ["--http", "--bind-all"])
+            assert result.exit_code == 0, result.output
+            args, kwargs = mock_instance.serve.call_args
+            host = args[1] if len(args) >= 2 else kwargs["host"]
+            assert host == "0.0.0.0"
+
+    def test_bind_all_emits_warning(self, runner, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "secret")
+        with _patched_server() as mock_cls:
+            mock_cls.return_value = MagicMock()
+            result = runner.invoke(mcp, ["--http", "--bind-all"])
+            assert result.exit_code == 0, result.output
+            combined = (result.output or "") + (result.stderr_bytes or b"").decode(errors="ignore")
+            assert "WARNING" in combined or "warning" in combined.lower()
+
+
+class TestTokenGate:
+    def test_http_without_token_exits(self, runner):
+        with _patched_server() as mock_cls:
+            mock_cls.return_value = MagicMock()
+            result = runner.invoke(mcp, ["--http"])
+            assert result.exit_code != 0
+            assert "SCRAPLING_MCP_TOKEN" in (result.output or "")
+
+    def test_http_with_blank_token_exits(self, runner, monkeypatch):
+        monkeypatch.setenv("SCRAPLING_MCP_TOKEN", "   ")
+        with _patched_server() as mock_cls:
+            mock_cls.return_value = MagicMock()
+            result = runner.invoke(mcp, ["--http"])
+            assert result.exit_code != 0
+            assert "SCRAPLING_MCP_TOKEN" in (result.output or "")
+
+    def test_stdio_does_not_require_token(self, runner):
+        with _patched_server() as mock_cls:
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            result = runner.invoke(mcp, [])
+            assert result.exit_code == 0, result.output
+            mock_instance.serve.assert_called_once()


### PR DESCRIPTION
 ## Summary

This PR hardens the MCP HTTP transport with safer defaults and request-level authentication.

Main changes:

- Default MCP HTTP bind host is now `127.0.0.1`.
- Binding to all interfaces requires explicit `--bind-all`.
- HTTP MCP transport requires `SCRAPLING_MCP_TOKEN`.
- Each HTTP request must include `Authorization: Bearer <token>`.
- Token comparison uses constant-time comparison.
- stdio transport remains unaffected.
- MCP tool URLs are validated before network access.
- Private IPs, loopback, link-local, multicast, and metadata IP targets are rejected by default.
- Optional allowlist support is available through `SCRAPLING_MCP_ALLOWLIST`.
- Localhost access can be explicitly enabled for development with `SCRAPLING_MCP_ALLOW_LOCAL=1`.

## Files changed

New:

- `scrapling/core/_mcp_auth.py`
- `scrapling/core/_url_guard.py`
- `tests/ai/conftest.py`
- `tests/ai/test_mcp_http_auth.py`
- `tests/ai/test_url_guard.py`
- `tests/cli/test_mcp_cli.py`

Modified:

- `scrapling/cli.py`
- `scrapling/core/ai.py`

## Security impact

This reduces the risk of:

- accidentally exposing MCP HTTP on all network interfaces,
- unauthenticated MCP HTTP access,
- SSRF through MCP URL-taking tools,
- access to localhost, private networks, or cloud metadata endpoints through MCP tools.

## Backward compatibility

- stdio MCP usage is unchanged.
- HTTP MCP users must now set `SCRAPLING_MCP_TOKEN`.
- Binding to `0.0.0.0`, `::`, or `*` now requires `--bind-all`.
- Local/private URL targets are blocked by default unless explicitly allowed for development.

## Test plan

Passed locally on Windows / Python 3.13:

- `python -m pytest tests\ai\test_mcp_http_auth.py -v` → 15 passed
- `python -m pytest tests\cli\test_mcp_cli.py -v` → 11 passed
- `python -m pytest tests\ai\test_ai_mcp.py -v` → 27 passed
- `python -m pytest tests\ai\test_url_guard.py -v` → 31 passed
- `python -m pytest tests\ai\ tests\cli\test_mcp_cli.py -v` → 84 passed

## Out of scope

This PR intentionally does not include:

- credential redaction,
- Docker/CI hardening,
- adaptive parser changes,
- release/version changes,
- README or CHANGELOG changes.