### PR TITLE
fix: bump browser stack for persistent init scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Install all browsers dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install playwright==1.59.0 patchright==1.59.1
+        python3 -m pip install playwright==1.60.0 patchright==1.60.0
 
     - name: Get Playwright version
       id: playwright-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,8 @@ dependencies = [
 fetchers = [
     "click>=8.3.0",
     "curl_cffi>=0.15.0",
-    "playwright==1.59.0",
-    "patchright==1.59.1",
+    "playwright==1.60.0",
+    "patchright==1.60.0",
     "browserforge>=1.2.4",
     "apify-fingerprint-datapoints>=0.13.0",
     "msgspec>=0.21.1",

--- a/tests/fetchers/async/test_stealth_session.py
+++ b/tests/fetchers/async/test_stealth_session.py
@@ -84,3 +84,17 @@ class TestAsyncStealthySession:
             # Test with invalid URL
             with pytest.raises(Exception):
                 await session.fetch("invalid://url")
+
+    async def test_init_script_with_user_data_dir(self, urls, tmp_path):
+        """Test init script injection with a persistent user data directory"""
+        init_script = tmp_path / "init.js"
+        init_script.write_text("window.__scraplingInitScriptLoaded = true;", encoding="utf-8")
+
+        async with AsyncStealthySession(
+                headless=True,
+                user_data_dir=str(tmp_path / "profile"),
+                init_script=str(init_script),
+        ) as session:
+            response = await session.fetch(urls["basic"])
+
+        assert response.status == 200

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest>=2.8.0,<9
 pytest-cov
-playwright==1.59.0
+playwright==1.60.0
 werkzeug<3.0.0
 pytest-httpbin==2.1.0
 pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ envlist = pre-commit,py{310,311,312,313}
 usedevelop = True
 changedir = tests
 deps =
-    playwright==1.59.0
-    patchright==1.59.1
+    playwright==1.60.0
+    patchright==1.60.0
     -r{toxinidir}/tests/requirements.txt
 extras = ai,shell
 commands =


### PR DESCRIPTION
## Proposed change

Bump the browser automation pins to Playwright/Patchright 1.60.0 so persistent stealth sessions can use `init_script` with `user_data_dir` without Patchright redirecting document navigations to the internal injection host.

This also adds a regression test that opens an `AsyncStealthySession` with both options and fetches the local httpbin fixture successfully.

### Type of change:

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information

- This PR fixes or closes an issue: fixes #294
- This PR is related to an issue: #294
- Link to documentation pull request: **

Before the dependency bump, the new regression test failed with `Page.goto: net::ERR_NAME_NOT_RESOLVED` when `init_script` and `user_data_dir` were used together.

Testing:
- `pytest tests/fetchers/async/test_stealth_session.py -k "init_script_with_user_data_dir" -q` (failed before the bump with `ERR_NAME_NOT_RESOLVED`)
- `pip install -e '.[fetchers]' -r tests/requirements.txt`
- `python -m playwright install chromium`
- `python -m patchright install chromium`
- `pytest tests/fetchers/async/test_stealth_session.py -k "init_script_with_user_data_dir" -q`
- `pytest tests/fetchers/async/test_stealth_session.py tests/fetchers/sync/test_stealth_session.py -q`
- `pytest tests/fetchers/async/test_dynamic_session.py tests/fetchers/sync/test_dynamic.py -q`
- `pytest tests/fetchers -q`
- `pre-commit run --files tests/fetchers/async/test_stealth_session.py pyproject.toml tox.ini tests/requirements.txt .github/workflows/tests.yml`
- `tox -e py313`
- `git diff --check`

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.
