### PR TITLE
fix: apply session-level proxy when no per-request proxy is given (#295)

### DIFF
--- a/scrapling/engines/static.py
+++ b/scrapling/engines/static.py
@@ -30,6 +30,8 @@ from ._browsers._types import RequestsSession, GetRequestParams, DataRequestPara
 from .toolbelt.fingerprints import generate_headers, __default_useragent__
 
 _NO_SESSION: Any = object()
+# Sentinel for "argument not provided", so an explicit ``None`` can be told apart from omission.
+_UNSET: Any = object()
 
 
 def _select_random_browser(impersonate: ImpersonateType) -> Optional[BrowserTypeLiteral]:
@@ -97,6 +99,25 @@ class _ConfigurationLogic(ABC):
     def _get_param(kwargs: Dict, key: str, default: Any) -> Any:
         """Get parameter from kwargs if present, otherwise return default."""
         return kwargs[key] if key in kwargs else default
+
+    def _resolve_proxy(self, request_proxy: Any = _UNSET) -> Any:
+        """Resolve the effective singular ``proxy`` for a single request.
+
+        Precedence, highest first:
+        1. An explicit per-request ``proxy`` (including ``None`` to drop the session ``proxy``).
+        2. The next proxy from the rotator, when one is configured.
+        3. The session-level default ``proxy``.
+
+        ``request_proxy`` stays ``_UNSET`` when the caller omitted it, so an explicit
+        ``proxy=None`` is not mistaken for "unset" and the session default is applied only
+        when no per-request proxy was given (the conflation behind #295). The plural
+        ``proxies`` mapping is resolved separately in :meth:`_merge_request_args`.
+        """
+        if request_proxy is not _UNSET:
+            return request_proxy
+        if self._proxy_rotator:
+            return self._proxy_rotator.get_proxy()
+        return self._default_proxy
 
     def _merge_request_args(self, **method_kwargs) -> Dict[str, Any]:
         """Merge request-specific arguments with default session arguments."""
@@ -229,7 +250,7 @@ class _SyncSessionLogic(_ConfigurationLogic):
         selector_config = self._get_param(kwargs, "selector_config", self.selector_config) or self.selector_config
         max_retries = self._get_param(kwargs, "retries", self._default_retries)
         retry_delay = self._get_param(kwargs, "retry_delay", self._default_retry_delay)
-        static_proxy = kwargs.pop("proxy", None)
+        request_proxy = kwargs.pop("proxy", _UNSET)
 
         session = self._curl_session
         one_off_request = False
@@ -244,10 +265,7 @@ class _SyncSessionLogic(_ConfigurationLogic):
 
         try:
             for attempt in range(max_retries):
-                if self._proxy_rotator and static_proxy is None:
-                    proxy = self._proxy_rotator.get_proxy()
-                else:
-                    proxy = static_proxy
+                proxy = self._resolve_proxy(request_proxy)
 
                 request_args = self._merge_request_args(stealth=stealth, proxy=proxy, **kwargs)
                 try:
@@ -443,7 +461,7 @@ class _ASyncSessionLogic(_ConfigurationLogic):
         selector_config = self._get_param(kwargs, "selector_config", self.selector_config) or self.selector_config
         max_retries = self._get_param(kwargs, "retries", self._default_retries)
         retry_delay = self._get_param(kwargs, "retry_delay", self._default_retry_delay)
-        static_proxy = kwargs.pop("proxy", None)
+        request_proxy = kwargs.pop("proxy", _UNSET)
 
         session = self._async_curl_session
         one_off_request = False
@@ -459,12 +477,8 @@ class _ASyncSessionLogic(_ConfigurationLogic):
             raise RuntimeError("No active session available.")  # pragma: no cover
 
         try:
-            # Determine if we should use proxy rotation
             for attempt in range(max_retries):
-                if self._proxy_rotator and static_proxy is None:
-                    proxy = self._proxy_rotator.get_proxy()
-                else:
-                    proxy = static_proxy
+                proxy = self._resolve_proxy(request_proxy)
 
                 request_args = self._merge_request_args(stealth=stealth, proxy=proxy, **kwargs)
                 try:

--- a/tests/fetchers/async/test_requests_session.py
+++ b/tests/fetchers/async/test_requests_session.py
@@ -1,6 +1,10 @@
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from curl_cffi.curl import CurlError
 
 
-from scrapling.engines.static import AsyncFetcherClient
+from scrapling.engines.static import AsyncFetcherClient, _ASyncSessionLogic as AsyncFetcherSession
+from scrapling.engines.toolbelt import ProxyRotator
 
 
 class TestFetcherSession:
@@ -13,3 +17,69 @@ class TestFetcherSession:
         # Should not have context manager methods
         assert client.__aenter__ is None
         assert client.__aexit__ is None
+
+    @pytest.mark.asyncio
+    async def test_session_level_proxy_is_applied(self):
+        """Session-level proxy must reach the request, not be silently dropped (#295)."""
+        proxy = "http://10.255.255.1:9999"
+        session = AsyncFetcherSession(proxy=proxy)
+
+        async with session as s:
+            with (
+                patch.object(s._async_curl_session, "request", new=AsyncMock()) as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_factory.return_value = MagicMock()
+                await s.get("http://example.com")
+
+            # The proxy forwarded to curl must be the session default, not None
+            assert mock_request.call_args.kwargs["proxy"] == proxy
+
+    @pytest.mark.asyncio
+    async def test_per_request_proxy_overrides_session_proxy(self):
+        """A per-request proxy must take precedence over the session-level proxy (#295)."""
+        request_proxy = "http://10.255.255.2:9999"
+        session = AsyncFetcherSession(proxy="http://10.255.255.1:9999")
+
+        async with session as s:
+            with (
+                patch.object(s._async_curl_session, "request", new=AsyncMock()) as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_factory.return_value = MagicMock()
+                await s.get("http://example.com", proxy=request_proxy)
+
+            assert mock_request.call_args.kwargs["proxy"] == request_proxy
+
+    @pytest.mark.asyncio
+    async def test_per_request_proxy_none_disables_session_proxy(self):
+        """An explicit per-request `proxy=None` must opt out of the session proxy (#295)."""
+        session = AsyncFetcherSession(proxy="http://10.255.255.1:9999")
+
+        async with session as s:
+            with (
+                patch.object(s._async_curl_session, "request", new=AsyncMock()) as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_factory.return_value = MagicMock()
+                await s.get("http://example.com", proxy=None)
+
+            assert mock_request.call_args.kwargs["proxy"] is None
+
+    @pytest.mark.asyncio
+    async def test_proxy_rotates_per_retry_attempt(self):
+        """With a rotator, every retry attempt must pull a fresh proxy (resolution stays in-loop)."""
+        rotator = ProxyRotator(["http://p1:8080", "http://p2:8080"])
+        session = AsyncFetcherSession(proxy_rotator=rotator, retries=2, retry_delay=0)
+
+        async with session as s:
+            with (
+                patch.object(s._async_curl_session, "request", new=AsyncMock()) as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_request.side_effect = [CurlError("transient"), MagicMock()]
+                mock_factory.return_value = MagicMock()
+                await s.get("http://example.com")
+
+            proxies_used = [call.kwargs["proxy"] for call in mock_request.call_args_list]
+            assert proxies_used == ["http://p1:8080", "http://p2:8080"]

--- a/tests/fetchers/sync/test_requests_session.py
+++ b/tests/fetchers/sync/test_requests_session.py
@@ -1,7 +1,10 @@
 import pytest
+from unittest.mock import patch, MagicMock
+from curl_cffi.curl import CurlError
 
 
 from scrapling.engines.static import _SyncSessionLogic as FetcherSession, FetcherClient
+from scrapling.engines.toolbelt import ProxyRotator
 
 
 class TestFetcherSession:
@@ -9,11 +12,7 @@ class TestFetcherSession:
 
     def test_fetcher_session_creation(self):
         """Test FetcherSession creation"""
-        session = FetcherSession(
-            timeout=30,
-            retries=3,
-            stealthy_headers=True
-        )
+        session = FetcherSession(timeout=30, retries=3, stealthy_headers=True)
 
         assert session._default_timeout == 30
         assert session._default_retries == 3
@@ -43,3 +42,82 @@ class TestFetcherSession:
         # Should not have context manager methods
         assert client.__enter__ is None
         assert client.__exit__ is None
+
+    def test_session_level_proxy_is_applied(self):
+        """Session-level proxy must reach the request, not be silently dropped (#295)."""
+        proxy = "http://10.255.255.1:9999"
+        session = FetcherSession(proxy=proxy)
+
+        with session as s:
+            with (
+                patch.object(s._curl_session, "request") as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_factory.return_value = MagicMock()
+                s.get("http://example.com")
+
+            # The proxy forwarded to curl must be the session default, not None
+            assert mock_request.call_args.kwargs["proxy"] == proxy
+
+    def test_per_request_proxy_overrides_session_proxy(self):
+        """A per-request proxy must take precedence over the session-level proxy (#295)."""
+        session_proxy = "http://10.255.255.1:9999"
+        request_proxy = "http://10.255.255.2:9999"
+        session = FetcherSession(proxy=session_proxy)
+
+        with session as s:
+            with (
+                patch.object(s._curl_session, "request") as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_factory.return_value = MagicMock()
+                s.get("http://example.com", proxy=request_proxy)
+
+            assert mock_request.call_args.kwargs["proxy"] == request_proxy
+
+    def test_per_request_proxy_none_disables_session_proxy(self):
+        """An explicit per-request `proxy=None` must opt out of the session proxy (#295)."""
+        session = FetcherSession(proxy="http://10.255.255.1:9999")
+
+        with session as s:
+            with (
+                patch.object(s._curl_session, "request") as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_factory.return_value = MagicMock()
+                s.get("http://example.com", proxy=None)
+
+            assert mock_request.call_args.kwargs["proxy"] is None
+
+    def test_per_request_proxy_none_skips_rotator(self):
+        """An explicit per-request `proxy=None` must override the rotator and disable proxying (#295)."""
+        # A consulted rotator would yield "http://p1:8080", so a None reaching curl proves it was skipped.
+        rotator = ProxyRotator(["http://p1:8080"])
+        session = FetcherSession(proxy_rotator=rotator)
+
+        with session as s:
+            with (
+                patch.object(s._curl_session, "request") as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_factory.return_value = MagicMock()
+                s.get("http://example.com", proxy=None)
+
+            assert mock_request.call_args.kwargs["proxy"] is None
+
+    def test_proxy_rotates_per_retry_attempt(self):
+        """With a rotator, every retry attempt must pull a fresh proxy (resolution stays in-loop)."""
+        rotator = ProxyRotator(["http://p1:8080", "http://p2:8080"])
+        session = FetcherSession(proxy_rotator=rotator, retries=2, retry_delay=0)
+
+        with session as s:
+            with (
+                patch.object(s._curl_session, "request") as mock_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request") as mock_factory,
+            ):
+                mock_request.side_effect = [CurlError("transient"), MagicMock()]
+                mock_factory.return_value = MagicMock()
+                s.get("http://example.com")
+
+            proxies_used = [call.kwargs["proxy"] for call in mock_request.call_args_list]
+            assert proxies_used == ["http://p1:8080", "http://p2:8080"]


### PR DESCRIPTION
## The bug (#295)

`FetcherSession(proxy=...)` is silently ignored: requests go direct and leak the real client IP. Passing `proxy=` per request works, only the session-level default is broken. Same on the async path.

```python
from scrapling.fetchers import FetcherSession
with FetcherSession(proxy="http://10.255.255.1:9999", timeout=8, retries=1) as s:
    r = s.get("http://httpbin.org/ip")
    print(r.status, r.body)   # expected: timeout. actual: 200 {"origin": "<real public IP>"}
```

## Root cause

`_make_request` does `static_proxy = kwargs.pop("proxy", None)` and then always re-passes `proxy=<value-or-None>` into `_merge_request_args`. Since `_get_param` treats a present-but-`None` key as an explicit value, the `self._default_proxy` fallback is dead. The underlying issue is that the code conflates "argument omitted" with "argument is `None`".

## Fix

Resolve the effective proxy in a single shared `_ConfigurationLogic._resolve_proxy` helper used by both the sync and async `_make_request`, with explicit precedence:

1. an explicit per-request `proxy` (including `None` to deliberately disable proxying)
2. the next proxy from the rotator, when one is configured
3. the session-level default `proxy`

A module-level `_UNSET` sentinel distinguishes an omitted `proxy` from an explicit `proxy=None`, removing the conflation that caused the leak. No new dependencies.

## Tests

Added sync + async coverage:
- omitted proxy inherits the session default (the regression itself)
- a per-request proxy overrides the session proxy
- explicit `proxy=None` disables proxying
- `proxy=None` skips the rotator
- the rotator yields a fresh proxy on each retry attempt

All assert on the `proxy` argument that actually reaches `curl_cffi`'s `session.request`. Reverting the fix fails the regression tests.

## Notes / scope

- One intentional behavior change: with a rotator configured, an explicit per-request `proxy=None` now means "no proxy for this request" instead of "use the rotator". An *omitted* proxy still uses the rotator.
- **Out of scope (follow-up):** this PR fixes the singular `proxy` only. The plural `proxies` mapping is resolved separately in `_merge_request_args` and already honors the session default, but the `proxy`/`proxies` interaction (e.g. an explicit per-request `proxy` not suppressing a session-level `proxies`) is a pre-existing design question I left untouched here. Happy to follow up if you'd like it handled.
- Targets `dev` per CONTRIBUTING.md. Ruff, ruff-format, vermin (`-t=3.10-`), and bandit pass on the changed code; the fetcher test suites pass locally.

Closes #295