### PR TITLE
Validate checkpoint callback identity

### DIFF
--- a/scrapling/spiders/request.py
+++ b/scrapling/spiders/request.py
@@ -29,6 +29,21 @@ def _stable_value_repr(value: Any) -> str:
         return repr(value)
 
 
+def _callback_identity(callback: Callable | None) -> dict[str, str | None] | None:
+    if callback is None:
+        return None
+
+    owner = getattr(callback, "__self__", None)
+    owner_cls = owner.__class__ if owner is not None else None
+    return {
+        "name": getattr(callback, "__name__", None),
+        "qualname": getattr(callback, "__qualname__", None),
+        "module": getattr(callback, "__module__", None),
+        "owner_class": getattr(owner_cls, "__qualname__", None),
+        "owner_module": getattr(owner_cls, "__module__", None),
+    }
+
+
 class Request:
     def __init__(
         self,
@@ -151,15 +166,17 @@ class Request:
         return self._fp == other._fp
 
     def __getstate__(self) -> dict[str, Any]:
-        """Prepare state for pickling - store callback as name string for pickle compatibility."""
+        """Prepare state for pickling - store callback identity for safe restoration."""
         state = self.__dict__.copy()
         state["_callback_name"] = getattr(self.callback, "__name__", None) if self.callback is not None else None
+        state["_callback_identity"] = _callback_identity(self.callback)
         state["callback"] = None  # Don't pickle the actual callable
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Restore state from pickle - callback restored later via _restore_callback()."""
         self._callback_name: str | None = state.pop("_callback_name", None)
+        self._callback_identity: dict[str, str | None] | None = state.pop("_callback_identity", None)
         self.__dict__.update(state)
 
     def _restore_callback(self, spider: "Spider") -> None:
@@ -168,7 +185,22 @@ class Request:
         :param spider: Spider instance to look up callback method on
         """
         if hasattr(self, "_callback_name") and self._callback_name:
-            self.callback = getattr(spider, self._callback_name, None) or spider.parse
+            callback = getattr(spider, self._callback_name, None)
+            if callback is None:
+                raise AttributeError(f"Callback '{self._callback_name}' not found on {spider.__class__.__name__}")
+
+            expected_identity = getattr(self, "_callback_identity", None)
+            if expected_identity is None:
+                raise ValueError("Checkpoint is missing callback identity metadata")
+            if _callback_identity(callback) != expected_identity:
+                raise ValueError(
+                    f"Callback '{self._callback_name}' does not match the checkpointed callback identity"
+                )
+
+            self.callback = callback
             del self._callback_name
+            del self._callback_identity
         elif hasattr(self, "_callback_name"):
             del self._callback_name
+            if hasattr(self, "_callback_identity"):
+                del self._callback_identity

--- a/tests/spiders/test_engine.py
+++ b/tests/spiders/test_engine.py
@@ -612,6 +612,26 @@ class TestCheckpointMethods:
             assert checkpoint_path.exists()
 
     @pytest.mark.asyncio
+    async def test_restore_checkpoint_rejects_callback_identity_mismatch(self):
+        class AdminSpider(MockSpider):
+            async def parse_item(self, response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
+                yield {"admin": True}
+
+        class PublicSpider(MockSpider):
+            async def parse_item(self, response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
+                yield {"public": True}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            admin = AdminSpider()
+            engine = _make_engine(spider=admin, crawldir=tmpdir)
+            await engine.scheduler.enqueue(Request("https://example.com/admin", sid="default", callback=admin.parse_item))
+            await engine._save_checkpoint()
+
+            public_engine = _make_engine(spider=PublicSpider(), crawldir=tmpdir)
+            with pytest.raises(ValueError, match="does not match the checkpointed callback identity"):
+                await public_engine._restore_from_checkpoint()
+
+    @pytest.mark.asyncio
     async def test_restore_when_no_checkpoint_returns_false(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             engine = _make_engine(crawldir=tmpdir)

--- a/tests/spiders/test_request.py
+++ b/tests/spiders/test_request.py
@@ -285,7 +285,7 @@ class TestRequestPickling:
         assert restored.callback is None
 
     def test_pickle_with_callback_stores_name(self):
-        """Test that callback name is stored when pickling."""
+        """Test that callback identity is stored when pickling."""
 
         async def parse_page(response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
             yield {"data": "test"}
@@ -295,6 +295,13 @@ class TestRequestPickling:
         # Check getstate stores callback name
         state = original.__getstate__()
         assert state["_callback_name"] == "parse_page"
+        assert state["_callback_identity"] == {
+            "name": "parse_page",
+            "qualname": parse_page.__qualname__,
+            "module": parse_page.__module__,
+            "owner_class": None,
+            "owner_module": None,
+        }
         assert state["callback"] is None
 
     def test_pickle_with_none_callback(self):
@@ -303,11 +310,19 @@ class TestRequestPickling:
 
         state = original.__getstate__()
         assert state["_callback_name"] is None
+        assert state["_callback_identity"] is None
         assert state["callback"] is None
 
-    def test_setstate_stores_callback_name(self):
-        """Test that setstate correctly handles callback name."""
+    def test_setstate_stores_callback_identity(self):
+        """Test that setstate correctly handles callback identity."""
         request = Request("https://example.com")
+        callback_identity = {
+            "name": "custom_parse",
+            "qualname": "MockSpider.custom_parse",
+            "module": "tests.spiders.test_request",
+            "owner_class": "MockSpider",
+            "owner_module": "tests.spiders.test_request",
+        }
         state = {
             "url": "https://example.com",
             "sid": "",
@@ -318,12 +333,15 @@ class TestRequestPickling:
             "_retry_count": 0,
             "_session_kwargs": {},
             "_callback_name": "custom_parse",
+            "_callback_identity": callback_identity,
         }
 
         request.__setstate__(state)
 
         assert hasattr(request, "_callback_name")
         assert request._callback_name == "custom_parse"
+        assert hasattr(request, "_callback_identity")
+        assert request._callback_identity == callback_identity
 
     def test_pickle_roundtrip_preserves_session_kwargs(self):
         """Test that session kwargs are preserved through pickle."""
@@ -360,14 +378,22 @@ class TestRequestRestoreCallback:
         spider = MockSpider()
         request = Request("https://example.com")
         request._callback_name = "parse_detail"
+        request._callback_identity = {
+            "name": "parse_detail",
+            "qualname": "TestRequestRestoreCallback.test_restore_callback_from_spider.<locals>.MockSpider.parse_detail",
+            "module": __name__,
+            "owner_class": "TestRequestRestoreCallback.test_restore_callback_from_spider.<locals>.MockSpider",
+            "owner_module": __name__,
+        }
 
         request._restore_callback(spider)  # type: ignore[arg-type]
 
         assert request.callback == spider.parse_detail
         assert not hasattr(request, "_callback_name")
+        assert not hasattr(request, "_callback_identity")
 
-    def test_restore_callback_falls_back_to_parse(self):
-        """Test that missing callback falls back to spider.parse."""
+    def test_restore_callback_raises_for_missing_callback(self):
+        """Test that missing callback is not silently restored to parse."""
 
         class MockSpider:
             async def parse(self, response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
@@ -376,11 +402,39 @@ class TestRequestRestoreCallback:
         spider = MockSpider()
         request = Request("https://example.com")
         request._callback_name = "nonexistent_method"
+        request._callback_identity = {
+            "name": "nonexistent_method",
+            "qualname": "MockSpider.nonexistent_method",
+            "module": __name__,
+            "owner_class": "MockSpider",
+            "owner_module": __name__,
+        }
 
-        request._restore_callback(spider)  # type: ignore[arg-type]
+        with pytest.raises(AttributeError, match="Callback 'nonexistent_method' not found"):
+            request._restore_callback(spider)  # type: ignore[arg-type]
 
-        assert request.callback == spider.parse
-        assert not hasattr(request, "_callback_name")
+    def test_restore_callback_rejects_identity_mismatch(self):
+        """Test same callback name on a different spider class is rejected."""
+
+        class AdminSpider:
+            async def parse(self, response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
+                yield None
+
+            async def parse_item(self, response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
+                yield {"admin": True}
+
+        class PublicSpider:
+            async def parse(self, response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
+                yield None
+
+            async def parse_item(self, response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
+                yield {"public": True}
+
+        request = Request("https://example.com", callback=AdminSpider().parse_item)
+        restored = pickle.loads(pickle.dumps(request))
+
+        with pytest.raises(ValueError, match="does not match the checkpointed callback identity"):
+            restored._restore_callback(PublicSpider())  # type: ignore[arg-type]
 
     def test_restore_callback_with_none_name(self):
         """Test restore callback when _callback_name is None."""
@@ -392,11 +446,13 @@ class TestRequestRestoreCallback:
         spider = MockSpider()
         request = Request("https://example.com")
         request._callback_name = None
+        request._callback_identity = None
 
         request._restore_callback(spider)  # type: ignore[arg-type]
 
         # Should clean up _callback_name attribute
         assert not hasattr(request, "_callback_name")
+        assert not hasattr(request, "_callback_identity")
 
     def test_restore_callback_without_callback_name_attr(self):
         """Test restore callback when _callback_name attribute doesn't exist."""


### PR DESCRIPTION
## Proposed change

Validate checkpoint callback identity before restoring request callbacks. Checkpointed requests now store callback name, qualname, module, owner class, and owner module, and restore rejects missing or mismatched callback identities instead of silently binding a request to another spider's same-named method.

This prevents checkpoint resume from dispatching a preserved request/response to the wrong spider callback when different spiders share callback names.


### Type of change:



- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information

- This PR fixes or closes an issue: Fixes #307
- This PR is related to an issue: #307
- Link to documentation pull request: **

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing).
* [x] All functions have doc-strings.

### Testing

- `python -m pytest tests/spiders/test_request.py tests/spiders/test_engine.py::TestCheckpointMethods tests/spiders/test_templates.py::TestCrawlSpiderPickle tests/spiders/test_sitemap.py::TestSitemapSpiderPickle -q`
- `python -m pytest tests/spiders -q`