### PR TITLE
Fix development cache key auth context

### DIFF
--- a/docs/spiders/advanced.md
+++ b/docs/spiders/advanced.md
@@ -129,7 +129,7 @@ class MySpider(Spider):
 
 ### How It Works
 
-1. **Cache key**: Each response is keyed by the request's fingerprint, so any change to fingerprint-affecting attributes (`fp_include_kwargs`, `fp_include_headers`, `fp_keep_fragments`) will produce a fresh fetch.
+1. **Cache key**: Each response is keyed by a development-cache fingerprint that includes the request URL, method, body, session ID, headers, and request kwargs. This keeps cached responses separate when authorization headers, cookies, or other request context changes.
 2. **Storage format**: One JSON file per response, named `{fingerprint_hex}.json`. The body is base64-encoded so binary content is preserved exactly. Writes are atomic (temp file + rename).
 3. **Replay**: On a cache hit, the engine skips the network entirely, including `download_delay`, rate limiting, and the `is_blocked()` retry path. The cached response goes straight to your callback.
 4. **Stats**: Cached requests still count toward `requests_count`, `response_bytes`, and the per-status counters, so your stat output looks the same as a normal crawl. Two extra counters, `cache_hits` and `cache_misses`, let you see how the cache performed.

--- a/scrapling/spiders/engine.py
+++ b/scrapling/spiders/engine.py
@@ -181,8 +181,14 @@ class CrawlerEngine:
         else:
             delay = self.spider.download_delay
 
-        if self._cache_manager and request._fp is not None:
-            cached = await self._cache_manager.get(request._fp)
+        cache_fingerprint = None
+        if self._cache_manager:
+            sid = request.sid or self.session_manager.default_session_id
+            cache_fingerprint = request.cache_fingerprint(
+                self.spider.fp_keep_fragments, self.session_manager.cache_context(sid)
+            )
+        if self._cache_manager and cache_fingerprint is not None:
+            cached = await self._cache_manager.get(cache_fingerprint)
             if cached is not None:
                 cached.request = request
                 self.stats.cache_hits += 1
@@ -212,9 +218,9 @@ class CrawlerEngine:
                 await self.spider.on_error(request, e)
                 return
 
-        if self._cache_manager and request._fp is not None:
+        if self._cache_manager and cache_fingerprint is not None:
             self.stats.cache_misses += 1
-            await self._cache_manager.put(request._fp, response, request._session_kwargs.get("method", "GET"))
+            await self._cache_manager.put(cache_fingerprint, response, request._session_kwargs.get("method", "GET"))
 
         if await self.spider.is_blocked(response):
             self.stats.blocked_requests_count += 1

--- a/scrapling/spiders/request.py
+++ b/scrapling/spiders/request.py
@@ -12,6 +12,8 @@ from scrapling.core._types import Any, AsyncGenerator, Callable, Dict, Optional,
 if TYPE_CHECKING:
     from scrapling.spiders.spider import Spider
 
+_CACHE_FINGERPRINT_VERSION = 2
+
 
 def _convert_to_bytes(value: str | bytes) -> bytes:
     if isinstance(value, bytes):
@@ -81,6 +83,16 @@ class Request:
         if self._fp is not None:
             return self._fp
 
+        fp = self.fingerprint(include_kwargs, include_headers, keep_fragments)
+        self._fp = fp
+        return fp
+
+    def _fingerprint_data(
+        self,
+        include_kwargs: bool = False,
+        include_headers: bool = False,
+        keep_fragments: bool = False,
+    ) -> Dict[str, Any]:
         post_data = self._session_kwargs.get("data", {})
         body = b""
         if post_data:
@@ -96,7 +108,7 @@ class Request:
             post_data = self._session_kwargs.get("json", {})
             body = orjson.dumps(post_data) if post_data else b""
 
-        data: Dict[str, str | Tuple] = {
+        data: Dict[str, Any] = {
             "sid": self.sid,
             "body": body.hex(),
             "method": self._session_kwargs.get("method", "GET"),
@@ -117,11 +129,27 @@ class Request:
             # Some header normalization
             for key, value in headers.items():
                 processed_headers[_convert_to_bytes(key.lower()).hex()] = _convert_to_bytes(value).hex()
-            data["headers"] = tuple(processed_headers.items())
+            data["headers"] = tuple(sorted(processed_headers.items()))
 
-        fp = hashlib.sha1(orjson.dumps(data, option=orjson.OPT_SORT_KEYS), usedforsecurity=False).digest()
-        self._fp = fp
-        return fp
+        return data
+
+    def fingerprint(
+        self,
+        include_kwargs: bool = False,
+        include_headers: bool = False,
+        keep_fragments: bool = False,
+    ) -> bytes:
+        """Generate a request fingerprint without mutating the cached scheduler fingerprint."""
+        data = self._fingerprint_data(include_kwargs, include_headers, keep_fragments)
+        return hashlib.sha1(orjson.dumps(data, option=orjson.OPT_SORT_KEYS), usedforsecurity=False).digest()
+
+    def cache_fingerprint(self, keep_fragments: bool = False, cache_context: Any | None = None) -> bytes:
+        """Generate a development-cache fingerprint with full request context."""
+        data = self._fingerprint_data(include_kwargs=True, include_headers=True, keep_fragments=keep_fragments)
+        data["cache_fingerprint_version"] = _CACHE_FINGERPRINT_VERSION
+        if cache_context is not None:
+            data["cache_context"] = _stable_value_repr(cache_context)
+        return hashlib.sha256(orjson.dumps(data, option=orjson.OPT_SORT_KEYS), usedforsecurity=False).digest()
 
     def __repr__(self) -> str:
         callback_name = getattr(self.callback, "__name__", None) or "None"

--- a/scrapling/spiders/session.py
+++ b/scrapling/spiders/session.py
@@ -3,7 +3,7 @@ from asyncio import Lock
 from scrapling.spiders.request import Request
 from scrapling.engines.static import _ASyncSessionLogic
 from scrapling.engines.toolbelt.convertor import Response
-from scrapling.core._types import Set, cast, SUPPORTED_HTTP_METHODS
+from scrapling.core._types import Set, Dict, Any, cast, SUPPORTED_HTTP_METHODS
 from scrapling.fetchers import AsyncDynamicSession, AsyncStealthySession, FetcherSession
 
 Session = FetcherSession | AsyncDynamicSession | AsyncStealthySession
@@ -79,6 +79,32 @@ class SessionManager:
             available = ", ".join(self._sessions.keys())
             raise KeyError(f"Session '{session_id}' not found. Available: {available}")
         return self._sessions[session_id]
+
+    def cache_context(self, session_id: str) -> Dict[str, Any]:
+        """Return stable session fields that affect development-cache response identity."""
+        session = self.get(session_id)
+        context: Dict[str, Any] = {"session_type": f"{session.__class__.__module__}.{session.__class__.__qualname__}"}
+
+        default_headers = getattr(session, "_default_headers", None)
+        if default_headers:
+            context["headers"] = default_headers
+
+        client = getattr(session, "_client", None)
+        for attr in ("_curl_session", "_async_curl_session"):
+            curl_session = getattr(client, attr, None)
+            cookies = getattr(curl_session, "cookies", None)
+            if cookies:
+                context["cookies"] = repr(cookies)
+                break
+
+        config = getattr(session, "_config", None)
+        if config is not None:
+            for key in ("extra_headers", "cookies", "user_data_dir"):
+                value = getattr(config, key, None)
+                if value:
+                    context[key] = value
+
+        return context
 
     async def start(self) -> None:
         """Start all sessions that aren't already alive."""

--- a/tests/spiders/test_cache.py
+++ b/tests/spiders/test_cache.py
@@ -114,6 +114,7 @@ class MockSession:
     def __init__(self):
         self._is_alive = False
         self.fetch_count = 0
+        self.request_headers: list[dict[str, str]] = []
 
     async def __aenter__(self):
         self._is_alive = True
@@ -124,7 +125,10 @@ class MockSession:
 
     async def fetch(self, url: str, **kwargs):
         self.fetch_count += 1
-        return _make_response(url=url, body=b"<html>fetched</html>")
+        headers = dict(kwargs.get("headers") or {})
+        self.request_headers.append(headers)
+        token = headers.get("Authorization", "anonymous")
+        return _make_response(url=url, body=f"<html>{token}</html>".encode())
 
 
 class _LogCounterStub:
@@ -133,7 +137,7 @@ class _LogCounterStub:
 
 
 class MockSpider:
-    def __init__(self, cache_dir: str):
+    def __init__(self, cache_dir: str, headers: dict[str, str] | None = None):
         self.concurrent_requests = 4
         self.concurrent_requests_per_domain = 0
         self.download_delay = 0.0
@@ -149,6 +153,7 @@ class MockSpider:
         self.name = "test_cache_spider"
         self._log_counter = _LogCounterStub()
         self.scraped_items: list[dict] = []
+        self.headers = headers or {}
 
     async def parse(self, response) -> AsyncGenerator[Dict[str, Any] | Request | None, None]:
         yield {"url": str(response)}
@@ -173,7 +178,7 @@ class MockSpider:
         return request
 
     async def start_requests(self) -> AsyncGenerator[Request, None]:
-        yield Request("https://example.com/page1", sid="default")
+        yield Request("https://example.com/page1", sid="default", headers=self.headers)
 
 
 class TestDevelopmentModeIntegration:
@@ -217,6 +222,81 @@ class TestDevelopmentModeIntegration:
             assert engine2.stats.cache_hits == 1
             assert engine2.stats.cache_misses == 0
             assert engine2.stats.items_scraped == 1
+
+    @pytest.mark.anyio
+    async def test_different_authorization_headers_do_not_share_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            attacker_session = MockSession()
+            attacker_spider = MockSpider(cache_dir=tmpdir, headers={"Authorization": "Bearer attacker-token"})
+            sm = SessionManager()
+            sm.add("default", attacker_session)
+            engine = CrawlerEngine(attacker_spider, sm)
+
+            await engine.crawl()
+            assert attacker_session.fetch_count == 1
+            assert engine.stats.cache_misses == 1
+
+            victim_session = MockSession()
+            victim_spider = MockSpider(cache_dir=tmpdir, headers={"Authorization": "Bearer victim-token"})
+            sm2 = SessionManager()
+            sm2.add("default", victim_session)
+            engine2 = CrawlerEngine(victim_spider, sm2)
+
+            await engine2.crawl()
+            assert victim_session.fetch_count == 1
+            assert victim_session.request_headers == [{"Authorization": "Bearer victim-token"}]
+            assert engine2.stats.cache_hits == 0
+            assert engine2.stats.cache_misses == 1
+
+    @pytest.mark.anyio
+    async def test_same_authorization_header_uses_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            headers = {"Authorization": "Bearer stable-token"}
+            session = MockSession()
+            spider = MockSpider(cache_dir=tmpdir, headers=headers)
+            sm = SessionManager()
+            sm.add("default", session)
+            engine = CrawlerEngine(spider, sm)
+
+            await engine.crawl()
+            assert session.fetch_count == 1
+
+            session2 = MockSession()
+            spider2 = MockSpider(cache_dir=tmpdir, headers=headers)
+            sm2 = SessionManager()
+            sm2.add("default", session2)
+            engine2 = CrawlerEngine(spider2, sm2)
+
+            await engine2.crawl()
+            assert session2.fetch_count == 0
+            assert engine2.stats.cache_hits == 1
+            assert engine2.stats.cache_misses == 0
+
+    @pytest.mark.anyio
+    async def test_different_session_default_headers_do_not_share_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            attacker_session = MockSession()
+            attacker_session._default_headers = {"Authorization": "Bearer attacker-token"}
+            attacker_spider = MockSpider(cache_dir=tmpdir)
+            sm = SessionManager()
+            sm.add("default", attacker_session)
+            engine = CrawlerEngine(attacker_spider, sm)
+
+            await engine.crawl()
+            assert attacker_session.fetch_count == 1
+            assert engine.stats.cache_misses == 1
+
+            victim_session = MockSession()
+            victim_session._default_headers = {"Authorization": "Bearer victim-token"}
+            victim_spider = MockSpider(cache_dir=tmpdir)
+            sm2 = SessionManager()
+            sm2.add("default", victim_session)
+            engine2 = CrawlerEngine(victim_spider, sm2)
+
+            await engine2.crawl()
+            assert victim_session.fetch_count == 1
+            assert engine2.stats.cache_hits == 0
+            assert engine2.stats.cache_misses == 1
 
     @pytest.mark.anyio
     async def test_disabled_by_default(self):

--- a/tests/spiders/test_session.py
+++ b/tests/spiders/test_session.py
@@ -31,6 +31,19 @@ class MockSession:  # type: ignore[type-arg]
         pass
 
 
+class MockCookieJar:
+    def __init__(self, value: str):
+        self.value = value
+
+    def __repr__(self) -> str:
+        return f"MockCookieJar({self.value})"
+
+
+class MockCurlSession:
+    def __init__(self, cookies):
+        self.cookies = cookies
+
+
 class TestSessionManagerInit:
     """Test SessionManager initialization."""
 
@@ -201,6 +214,30 @@ class TestSessionManagerGet:
 
         with pytest.raises(KeyError, match="Available:"):
             manager.get("nonexistent")
+
+
+class TestSessionManagerCacheContext:
+    def test_cache_context_includes_default_headers(self):
+        manager = SessionManager()
+        session = MockSession()
+        session._default_headers = {"Authorization": "Bearer token"}
+        manager.add("default", session)
+
+        context = manager.cache_context("default")
+
+        assert context["headers"] == {"Authorization": "Bearer token"}
+
+    def test_cache_context_changes_with_cookie_jar(self):
+        manager = SessionManager()
+        session = MockSession()
+        session._client = type("Client", (), {"_async_curl_session": MockCurlSession(MockCookieJar("a=1"))})()
+        manager.add("default", session)
+
+        context = manager.cache_context("default")
+        session._client._async_curl_session.cookies = MockCookieJar("a=2")
+
+        assert context["cookies"] == "MockCookieJar(a=1)"
+        assert manager.cache_context("default")["cookies"] == "MockCookieJar(a=2)"
 
 
 class TestSessionManagerContains:


### PR DESCRIPTION
## Summary
- add a separate SHA-256 development-cache fingerprint with a schema version
- include request headers/kwargs plus session cache context such as default headers and cookies in the cache key
- keep scheduler deduplication fingerprints unchanged while preventing auth/cookie cache reuse
- update development-cache docs and add regression tests

Fixes D4Vinci/Scrapling#311

## Tests
- /tmp/scrapling-agent-verify-venv/bin/python -m pytest tests/spiders -q
- /tmp/scrapling-agent-verify-venv/bin/python -m ruff check scrapling/spiders/request.py scrapling/spiders/session.py scrapling/spiders/engine.py tests/spiders/test_cache.py tests/spiders/test_session.py