### PR TITLE
Fix auth-aware request deduplication

### DIFF
--- a/docs/spiders/architecture.md
+++ b/docs/spiders/architecture.md
@@ -53,7 +53,7 @@ The engine orchestrates the entire crawl. It manages the main loop, enforces con
 
 ### Scheduler
 
-A priority queue with built-in URL deduplication. Requests are fingerprinted based on their URL, HTTP method, body, and session ID. The scheduler supports `snapshot()` and `restore()` for the checkpoint system, allowing the crawl state to be saved and resumed.
+A priority queue with built-in URL deduplication. Requests are fingerprinted based on their URL, HTTP method, body, session ID, and authentication-related request context. The scheduler supports `snapshot()` and `restore()` for the checkpoint system, allowing the crawl state to be saved and resumed.
 
 ### Session Manager
 

--- a/docs/spiders/requests-responses.md
+++ b/docs/spiders/requests-responses.md
@@ -144,7 +144,7 @@ When using `response.follow()`, the priority is inherited from the original requ
 
 ## Deduplication
 
-The spider automatically deduplicates requests based on a fingerprint computed from the URL, HTTP method, request body, and session ID. If two requests produce the same fingerprint, the second one is silently dropped.
+The spider automatically deduplicates requests based on a fingerprint computed from the URL, HTTP method, request body, session ID, and authentication-related request context such as `Authorization`/`Cookie` headers and explicit `cookies`/`auth` kwargs. If two requests produce the same fingerprint, the second one is silently dropped.
 
 To allow duplicate requests (e.g., re-visiting a page after login), set `dont_filter=True`:
 

--- a/scrapling/spiders/request.py
+++ b/scrapling/spiders/request.py
@@ -12,6 +12,9 @@ from scrapling.core._types import Any, AsyncGenerator, Callable, Dict, Optional,
 if TYPE_CHECKING:
     from scrapling.spiders.spider import Spider
 
+_SECURITY_CONTEXT_HEADERS = frozenset({"authorization", "cookie"})
+_SECURITY_CONTEXT_KWARGS = frozenset({"auth", "cookies"})
+
 
 def _convert_to_bytes(value: str | bytes) -> bytes:
     if isinstance(value, bytes):
@@ -27,6 +30,16 @@ def _stable_value_repr(value: Any) -> str:
         return orjson.dumps(value, option=orjson.OPT_SORT_KEYS, default=repr).decode()
     except TypeError:
         return repr(value)
+
+
+def _process_headers(headers: Dict[str, Any], header_names: frozenset[str] | None = None) -> Tuple[Tuple[str, str], ...]:
+    processed_headers = {}
+    for key, value in headers.items():
+        normalized_key = key.lower()
+        if header_names is not None and normalized_key not in header_names:
+            continue
+        processed_headers[_convert_to_bytes(normalized_key).hex()] = _convert_to_bytes(value).hex()
+    return tuple(sorted(processed_headers.items()))
 
 
 class Request:
@@ -96,12 +109,29 @@ class Request:
             post_data = self._session_kwargs.get("json", {})
             body = orjson.dumps(post_data) if post_data else b""
 
-        data: Dict[str, str | Tuple] = {
+        data: Dict[str, Any] = {
             "sid": self.sid,
             "body": body.hex(),
             "method": self._session_kwargs.get("method", "GET"),
             "url": canonicalize_url(self.url, keep_fragments=keep_fragments),
         }
+
+        security_context_kwargs = {
+            key.lower(): _stable_value_repr(value)
+            for key, value in self._session_kwargs.items()
+            if key.lower() in _SECURITY_CONTEXT_KWARGS
+        }
+        if security_context_kwargs:
+            data["security_context_kwargs"] = tuple(sorted(security_context_kwargs.items()))
+
+        security_context_headers = []
+        for headers_key in ("headers", "extra_headers"):
+            headers = self._session_kwargs.get(headers_key) or {}
+            processed_headers = _process_headers(headers, _SECURITY_CONTEXT_HEADERS)
+            if processed_headers:
+                security_context_headers.append((headers_key, processed_headers))
+        if security_context_headers:
+            data["security_context_headers"] = tuple(security_context_headers)
 
         if include_kwargs:
             filtered_kwargs = {
@@ -113,11 +143,7 @@ class Request:
 
         if include_headers:
             headers = self._session_kwargs.get("headers") or self._session_kwargs.get("extra_headers") or {}
-            processed_headers = {}
-            # Some header normalization
-            for key, value in headers.items():
-                processed_headers[_convert_to_bytes(key.lower()).hex()] = _convert_to_bytes(value).hex()
-            data["headers"] = tuple(processed_headers.items())
+            data["headers"] = _process_headers(headers)
 
         fp = hashlib.sha1(orjson.dumps(data, option=orjson.OPT_SORT_KEYS), usedforsecurity=False).digest()
         self._fp = fp

--- a/tests/spiders/test_request.py
+++ b/tests/spiders/test_request.py
@@ -99,6 +99,37 @@ class TestRequestProperties:
         r2 = Request("https://example.com/page2")
         assert r1.update_fingerprint() != r2.update_fingerprint()
 
+    def test_fingerprint_auth_headers_differ_by_default(self):
+        """Test auth-bearing headers are included in the default fingerprint."""
+        r1 = Request("https://example.com/account", headers={"Authorization": "Bearer token-1"})
+        r2 = Request("https://example.com/account", headers={"Authorization": "Bearer token-2"})
+        r3 = Request("https://example.com/account", headers={"Cookie": "session=one"})
+        r4 = Request("https://example.com/account", headers={"Cookie": "session=two"})
+
+        assert r1.update_fingerprint() != r2.update_fingerprint()
+        assert r3.update_fingerprint() != r4.update_fingerprint()
+
+    def test_fingerprint_extra_auth_headers_differ_by_default(self):
+        """Test browser-style auth headers are included in the default fingerprint."""
+        r1 = Request("https://example.com/account", extra_headers={"Authorization": "Bearer token-1"})
+        r2 = Request("https://example.com/account", extra_headers={"Authorization": "Bearer token-2"})
+
+        assert r1.update_fingerprint() != r2.update_fingerprint()
+
+    def test_fingerprint_cookies_kwarg_differs_by_default(self):
+        """Test explicit cookies are included in the default fingerprint."""
+        r1 = Request("https://example.com/account", cookies={"session": "one"})
+        r2 = Request("https://example.com/account", cookies={"session": "two"})
+
+        assert r1.update_fingerprint() != r2.update_fingerprint()
+
+    def test_fingerprint_non_auth_headers_ignored_by_default(self):
+        """Test non-auth headers still require include_headers to affect fingerprints."""
+        r1 = Request("https://example.com", headers={"X-Test": "A"})
+        r2 = Request("https://example.com", headers={"X-Test": "B"})
+
+        assert r1.update_fingerprint() == r2.update_fingerprint()
+
     def test_fingerprint_include_kwargs_uses_kwarg_values(self):
         """Test kwargs with different values produce different fingerprints."""
         r1 = Request("https://example.com", timeout=1)

--- a/tests/spiders/test_scheduler.py
+++ b/tests/spiders/test_scheduler.py
@@ -89,6 +89,36 @@ class TestSchedulerEnqueue:
         assert result2 is True
         assert len(scheduler) == 2
 
+    @pytest.mark.asyncio
+    async def test_enqueue_different_authorization_headers_not_duplicate(self):
+        """Test auth-distinct requests are not filtered as duplicates."""
+        scheduler = Scheduler()
+
+        request1 = Request("https://example.com/account", sid="s1", headers={"Authorization": "Bearer token-1"})
+        request2 = Request("https://example.com/account", sid="s1", headers={"Authorization": "Bearer token-2"})
+
+        result1 = await scheduler.enqueue(request1)
+        result2 = await scheduler.enqueue(request2)
+
+        assert result1 is True
+        assert result2 is True
+        assert len(scheduler) == 2
+
+    @pytest.mark.asyncio
+    async def test_enqueue_different_cookies_not_duplicate(self):
+        """Test cookie-distinct requests are not filtered as duplicates."""
+        scheduler = Scheduler()
+
+        request1 = Request("https://example.com/account", sid="s1", cookies={"session": "one"})
+        request2 = Request("https://example.com/account", sid="s1", cookies={"session": "two"})
+
+        result1 = await scheduler.enqueue(request1)
+        result2 = await scheduler.enqueue(request2)
+
+        assert result1 is True
+        assert result2 is True
+        assert len(scheduler) == 2
+
 
 class TestSchedulerDequeue:
     """Test Scheduler dequeue functionality."""


### PR DESCRIPTION
## Summary
- include authentication-related request context in the default scheduler fingerprint
- keep non-auth headers behind `fp_include_headers` to preserve normal deduplication behavior
- add regression tests for Authorization, Cookie, `extra_headers`, and explicit `cookies` request context
- update scheduler deduplication docs

Closes #313

## Tests
- `pytest tests/spiders/test_request.py tests/spiders/test_scheduler.py`
- `ruff check scrapling/spiders/request.py tests/spiders/test_request.py tests/spiders/test_scheduler.py`