### PR TITLE
docs: fix re_first docstring to match implementation

### DIFF
--- a/scrapling/core/custom_types.py
+++ b/scrapling/core/custom_types.py
@@ -254,8 +254,8 @@ class TextHandlers(List[TextHandler]):
         clean_match: bool = False,
         case_sensitive: bool = True,
     ) -> TextHandler:  # pragma: no cover
-        """Call the ``.re_first()`` method for each element in this list and return
-        the first result or the default value otherwise.
+        """Run the given regex against each element in this list and return
+        the first match found, or the default value otherwise.
 
         :param regex: Can be either a compiled regular expression or a string.
         :param default: The default value to be returned if there is no match


### PR DESCRIPTION
The `re_first` docstring said it calls `.re_first()` on each element, but the implementation runs the given regex against each element and returns the first match (or the default value). Updated the docstring to describe the actual behavior.

Documentation only, no logic change. Verified that `tests/parser/` passes and `ruff check scrapling/core/custom_types.py` is clean.

Prepared with AI assistance.