### PR TITLE
docs: fix sponsor tier typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ MySpider().start()
 
 <!-- /sponsors -->
 
-<i><sub>Do you want to show your ad here? Click [here](https://github.com/sponsors/D4Vinci) and choose the tier that suites you!</sub></i>
+<i><sub>Do you want to show your ad here? Click [here](https://github.com/sponsors/D4Vinci) and choose the tier that suits you!</sub></i>
 
 ---
 


### PR DESCRIPTION
## Summary
- fix a typo in the README sponsor callout: suites you -> suits you

## Validation
- ran git diff --check
- checked the README for mojibake markers