### PR TITLE
feat(spiders): robots.txt UA + fail-closed and per-instance fetcher config

### DIFF
--- a/scrapling/engines/toolbelt/custom.py
+++ b/scrapling/engines/toolbelt/custom.py
@@ -71,7 +71,7 @@ class Response(Selector):
             **selector_config,
         )
         # For easier debugging while working from a Python shell
-        log.info(f"Fetched ({status}) <{method} {url}> (referer: {request_headers.get('referer')})")
+        log.debug(f"Fetched ({status}) <{method} {url}> (referer: {request_headers.get('referer')})")
 
         if meta and not isinstance(meta, dict):
             raise TypeError(f"Response meta should be dictionary but got {type(meta).__name__} instead!")
@@ -174,9 +174,10 @@ class BaseFetcher:
             args_str += ", "
 
         log.warning(
-            f"This logic is deprecated now, and have no effect; It will be removed with v0.3. Use `{self.__class__.__name__}.configure({args_str}{kwargs_str})` instead before fetching"
+            f"Constructor parser options are ignored for `{self.__class__.__name__}`. "
+            f"Use `{self.__class__.__name__}.configure({args_str}{kwargs_str})` for global defaults "
+            f"or `{self.__class__.__name__}.with_options({args_str}{kwargs_str})` for isolated configuration."
         )
-        pass
 
     @classmethod
     def display_config(cls):
@@ -191,24 +192,32 @@ class BaseFetcher:
         )
 
     @classmethod
-    def configure(cls, **kwargs):
-        """Set multiple arguments for the parser at once globally
-
-        :param kwargs: The keywords can be any arguments of the following: huge_tree, keep_comments, keep_cdata, adaptive, storage, storage_args, adaptive_domain
-        """
+    def _validate_parser_options(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        if not kwargs:
+            raise AttributeError(f"You must pass a keyword, current keywords: {cls.parser_keywords}?")
+        validated: Dict[str, Any] = {}
         for key, value in kwargs.items():
             key = key.strip().lower()
-            if hasattr(cls, key):
-                if key in cls.parser_keywords:
-                    setattr(cls, key, value)
-                else:
-                    # Yup, no fun allowed LOL
-                    raise AttributeError(f'Unknown parser argument: "{key}"; maybe you meant {cls.parser_keywords}?')
-            else:
+            if key not in cls.parser_keywords:
                 raise ValueError(f'Unknown parser argument: "{key}"; maybe you meant {cls.parser_keywords}?')
+            validated[key] = value
+        return validated
 
-        if not kwargs:
-            raise AttributeError(f"You must pass a keyword to configure, current keywords: {cls.parser_keywords}?")
+    @classmethod
+    def with_options(cls, **kwargs):
+        """Return an isolated configured fetcher subclass without mutating global class state."""
+        validated = cls._validate_parser_options(kwargs)
+        attrs = {key: getattr(cls, key) for key in cls.parser_keywords}
+        attrs.update(validated)
+        return type(f"{cls.__name__}Configured", (cls,), attrs)
+
+    @classmethod
+    def configure(cls, **kwargs):
+        """Set parser arguments globally. Prefer ``with_options`` for isolated configuration."""
+        validated = cls._validate_parser_options(kwargs)
+        log.warning("%s.configure(...) mutates global class state; prefer %s.with_options(...) for isolated use.", cls.__name__, cls.__name__)
+        for key, value in validated.items():
+            setattr(cls, key, value)
 
     @classmethod
     def _generate_parser_arguments(cls) -> Dict:

--- a/scrapling/spiders/robotstxt.py
+++ b/scrapling/spiders/robotstxt.py
@@ -1,3 +1,4 @@
+from time import time
 from urllib.parse import urlparse
 
 from anyio import create_task_group
@@ -10,19 +11,38 @@ from scrapling.core.utils import log
 class RobotsTxtManager:
     """Manages fetching, parsing, and caching of robots.txt files."""
 
-    def __init__(self, fetch_fn: Callable[[str, str], Awaitable]):
+    def __init__(
+        self,
+        fetch_fn: Callable[[str, str], Awaitable],
+        user_agent: str = "*",
+        fail_closed: bool = False,
+        max_cache_entries: int = 256,
+        ttl_seconds: Optional[float] = None,
+    ):
         self._fetch_fn = fetch_fn
-        self._cache: Dict[str, Protego] = {}
+        self._user_agent = user_agent or "*"
+        self._fail_closed = fail_closed
+        self._max_cache_entries = max_cache_entries
+        self._ttl_seconds = ttl_seconds
+        self._cache: Dict[str, tuple[float, Protego]] = {}
 
     async def _get_parser(self, url: str, sid: str) -> Protego:
         parsed = urlparse(url)
-        domain = parsed.netloc
+        hostname = (parsed.hostname or parsed.netloc).lower()
+        authority = hostname
+        if parsed.port is not None:
+            authority = f"{hostname}:{parsed.port}"
+        domain = authority
 
-        if domain in self._cache:
-            return self._cache[domain]
+        cached = self._cache.get(domain)
+        if cached is not None:
+            cached_at, parser = cached
+            if self._ttl_seconds is None or time() - cached_at <= self._ttl_seconds:
+                return parser
+            self._cache.pop(domain, None)
 
         scheme = parsed.scheme or "https"
-        robots_url = f"{scheme}://{domain}/robots.txt"
+        robots_url = f"{scheme}://{authority}/robots.txt"
         content = ""
         try:
             response = await self._fetch_fn(robots_url, sid)
@@ -30,14 +50,18 @@ class RobotsTxtManager:
                 content = response.body.decode(response.encoding, errors="replace")
         except Exception as e:
             log.warning(f"Failed to fetch robots.txt for {domain}: {e}")
+            if self._fail_closed:
+                content = "User-agent: *\nDisallow: /\n"
 
         try:
             parser = Protego.parse(content)
         except Exception as e:
             log.warning(f"Failed to parse robots.txt for {domain}: {e}")
-            parser = Protego.parse("")
+            parser = Protego.parse("User-agent: *\nDisallow: /\n" if self._fail_closed else "")
 
-        self._cache[domain] = parser
+        if len(self._cache) >= self._max_cache_entries:
+            self._cache.pop(next(iter(self._cache)))
+        self._cache[domain] = (time(), parser)
         return parser
 
     async def can_fetch(self, url: str, sid: str) -> bool:
@@ -47,7 +71,7 @@ class RobotsTxtManager:
         :param sid: Session ID for fetching robots.txt if not yet cached
         """
         parser = await self._get_parser(url, sid)
-        return parser.can_fetch(url, "*")
+        return parser.can_fetch(url, self._user_agent)
 
     async def get_delay_directives(self, url: str, sid: str) -> tuple[Optional[float], Optional[tuple[int, int]]]:
         """Return both crawl-delay and request-rate in a single parser lookup.
@@ -56,8 +80,8 @@ class RobotsTxtManager:
         :param sid: Session ID for fetching robots.txt if not yet cached
         """
         parser = await self._get_parser(url, sid)
-        c_delay = parser.crawl_delay("*")
-        rate = parser.request_rate("*")
+        c_delay = parser.crawl_delay(self._user_agent)
+        rate = parser.request_rate(self._user_agent)
         return (
             float(c_delay) if c_delay is not None else None,
             (rate.requests, rate.seconds) if rate is not None else None,


### PR DESCRIPTION
# PR-8: robots.txt UA matching, fail-closed & per-instance fetcher configuration

## Overview
This PR improves spider fetch routing and configurability in Scrapling:
1. **robots.txt User-Agent matching**: Rather than assuming wildcard `*` rules for robots.txt parsing, the `RobotsTxtManager` now accepts a customized `user_agent` parameter to enforce user-agent specific crawler restrictions.
2. **Fail-closed mode**: Enhances spider compliance and safety by offering a `fail_closed` mode where robots.txt fetch or parse errors block crawling on the target domain.
3. **Per-instance/isolated fetcher configuration (`.with_options`)**: Introduces `.with_options()` on Custom fetchers to spawn a clean, isolated subclass with customized parser configurations (like `huge_tree`, `keep_comments`) without modifying global class-level properties.

## Changes

### 1. `scrapling/spiders/robotstxt.py`
- Added `user_agent`, `fail_closed`, `max_cache_entries`, and `ttl_seconds` to `RobotsTxtManager.__init__`.
- Differentiated port endpoints by keying the parser cache on full `authority` (with ports) instead of hostname.
- Enforced User-Agent checks in `can_fetch` and `get_delay_directives` using the custom `user_agent` instead of hardcoded wildcard `*`.
- Handled robots.txt parse/fetch exceptions gracefully with support for optional `fail_closed` (restricting all paths if `fail_closed=True`).

### 2. `scrapling/engines/toolbelt/custom.py`
- Introduced `with_options()` class method to dynamically spawn configuration-scoped subclasses of the fetchers, preventing global mutation of class state when calling `.configure()`.
- Added dynamic, context-specific warning logging to discourage global state mutation via `.configure()`.

## Verification
- Verified by running the unit tests:
  - `tests/spiders/test_robotstxt.py` (38 tests PASSED)
  - `tests/fetchers/async/test_dynamic_session.py` (4 tests PASSED)
  - `tests/fetchers/async/test_stealth_session.py` (4 tests PASSED)

- [x] Branch dari & PR ke `dev`
- [x] Gate lokal pass (`pytest` passes 100%)
