### PR TITLE
fix: resolve follow_redirects string modes to curl_cffi-accepted values (#336)

### DIFF
--- a/scrapling/engines/static.py
+++ b/scrapling/engines/static.py
@@ -4,7 +4,7 @@ from time import sleep as time_sleep
 from asyncio import sleep as asyncio_sleep
 
 from curl_cffi.curl import CurlError
-from curl_cffi import CurlHttpVersion
+from curl_cffi import CurlFollow, CurlHttpVersion
 from curl_cffi.requests import (
     BrowserTypeLiteral,
     Session as CurlSession,
@@ -30,6 +30,30 @@ from ._browsers._types import RequestsSession, GetRequestParams, DataRequestPara
 from .toolbelt.fingerprints import generate_headers, __default_useragent__
 
 _NO_SESSION: Any = object()
+
+# Maps Scrapling's ` FollowRedirects ` string modes to the ` CurlFollow ` enum
+# that ` curl_cffi ` consumes. curl_cffi turns ` allow_redirects ` into a curl
+# option via ` int(allow_redirects) `, so forwarding a raw string such as "all"
+# raises ` ValueError: invalid literal for int() ` (issue #336). Resolving the
+# string here keeps us robust across curl_cffi versions instead of relying on
+# its internal "safe"-only special case.
+_FOLLOW_REDIRECTS_MAP: Dict[str, CurlFollow] = {
+    "safe": CurlFollow.SAFE,
+    "all": CurlFollow.ALL,
+    "obeycode": CurlFollow.OBEYCODE,
+    "firstonly": CurlFollow.FIRSTONLY,
+}
+
+
+def _resolve_follow_redirects(follow_redirects: Any) -> Any:
+    """Resolve a ` FollowRedirects ` value to something curl_cffi accepts.
+
+    String modes are mapped to their ` CurlFollow ` member; booleans and any
+    already-resolved ` CurlFollow ` values are passed through unchanged.
+    """
+    if isinstance(follow_redirects, str):
+        return _FOLLOW_REDIRECTS_MAP.get(follow_redirects, CurlFollow.SAFE)
+    return follow_redirects
 
 
 def _select_random_browser(impersonate: ImpersonateType) -> Optional[BrowserTypeLiteral]:
@@ -121,7 +145,9 @@ class _ConfigurationLogic(ABC):
             "proxy": self._get_param(method_kwargs, "proxy", self._default_proxy),
             "proxy_auth": self._get_param(method_kwargs, "proxy_auth", self._default_proxy_auth),
             "timeout": self._get_param(method_kwargs, "timeout", self._default_timeout),
-            "allow_redirects": self._get_param(method_kwargs, "follow_redirects", self._default_follow_redirects),
+            "allow_redirects": _resolve_follow_redirects(
+                self._get_param(method_kwargs, "follow_redirects", self._default_follow_redirects)
+            ),
             "max_redirects": self._get_param(method_kwargs, "max_redirects", self._default_max_redirects),
             "verify": self._get_param(method_kwargs, "verify", self._default_verify),
             "cert": self._get_param(method_kwargs, "cert", self._default_cert),

--- a/tests/fetchers/test_merge_request_args.py
+++ b/tests/fetchers/test_merge_request_args.py
@@ -1,9 +1,12 @@
 """Tests for _merge_request_args to ensure browser-only kwargs are excluded.
 
 Regression tests for https://github.com/D4Vinci/Scrapling/issues/247
+and https://github.com/D4Vinci/Scrapling/issues/336
 """
 
 import pytest
+
+from curl_cffi import CurlFollow
 
 from scrapling.engines.static import FetcherClient
 
@@ -42,3 +45,47 @@ class TestMergeRequestArgsSkipsBrowserParams:
         """Arbitrary curl_cffi-compatible kwargs should survive."""
         args = self._build_args(cookies={"session": "abc"})
         assert args.get("cookies") == {"session": "abc"}
+
+
+class TestMergeRequestArgsResolvesFollowRedirects:
+    """Verify that Scrapling's string ``follow_redirects`` modes are resolved
+    to a value ``curl_cffi`` accepts before being forwarded as
+    ``allow_redirects`` (fixes #336).
+
+    ``curl_cffi`` consumes ``allow_redirects`` via ``int(allow_redirects)``
+    for anything that is not a ``CurlFollow`` member (only the literal
+    ``"safe"`` is special-cased). Forwarding a raw string such as ``"all"``
+    therefore raises ``ValueError: invalid literal for int()``, which broke
+    every ``Fetcher.get()`` call when ``follow_redirects`` defaulted to the
+    string ``"safe"``.
+    """
+
+    def _build_args(self, **extra_kwargs):
+        """Helper: instantiate a FetcherClient and call _merge_request_args."""
+        client = FetcherClient()
+        return client._merge_request_args(url="https://example.com", **extra_kwargs)
+
+    def test_default_follow_redirects_resolved(self):
+        """The default (``"safe"``) must not leak through as a raw string."""
+        args = self._build_args()
+        allow_redirects = args["allow_redirects"]
+        assert not isinstance(allow_redirects, str)
+        # Whatever it resolves to must be int()-able the way curl_cffi expects.
+        int(allow_redirects)
+
+    @pytest.mark.parametrize("mode", ["safe", "all", "obeycode", "firstonly"])
+    def test_string_modes_resolved_to_curlfollow(self, mode):
+        """Every FollowRedirects literal must map to a curl_cffi-acceptable
+        value (a CurlFollow member or a bool), never a raw string."""
+        args = self._build_args(follow_redirects=mode)
+        allow_redirects = args["allow_redirects"]
+        assert isinstance(allow_redirects, (CurlFollow, bool))
+        # curl_cffi does int(allow_redirects); confirm this does not raise.
+        int(allow_redirects)
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_bool_modes_passed_through(self, value):
+        """Explicit boolean values are already curl_cffi-acceptable and must
+        be preserved as-is."""
+        args = self._build_args(follow_redirects=value)
+        assert args["allow_redirects"] is value


### PR DESCRIPTION
## What

`Fetcher.get()` (and the other HTTP verbs) raise `ValueError: invalid literal for int()` whenever `follow_redirects` is one of Scrapling's documented string modes. Since the default is `"safe"`, this can break basic fetches depending on the installed curl_cffi version.

## Why

`_ConfigurationLogic._merge_request_args` (scrapling/engines/static.py) forwarded the raw `follow_redirects` value straight to curl_cffi as `allow_redirects`. curl_cffi turns `allow_redirects` into a curl option via `int(allow_redirects)` and only special-cases the literal `"safe"` internally (curl_cffi/requests/utils.py). So `"all"`, `"obeycode"`, and `"firstonly"` hit `int("all")` and raise, and `"safe"` only survives by relying on that internal special case.

## Fix

- Add a module-level `_FOLLOW_REDIRECTS_MAP` + `_resolve_follow_redirects()` in `static.py` that map the four `FollowRedirects` string modes to the matching `CurlFollow` enum member (`from curl_cffi import CurlFollow`).
- Booleans and already-resolved `CurlFollow` values pass through unchanged.
- Unknown strings fall back to `CurlFollow.SAFE` (the SSRF-safe default), so a typo degrades safely rather than crashing — note this replaces the previous loud `ValueError` with a silent fallback.
- Resolve `"safe"` -> `CurlFollow.SAFE` ourselves so behavior no longer depends on curl_cffi's internal special-casing and is robust across versions.

## Tests

Added `TestMergeRequestArgsResolvesFollowRedirects` to `tests/fetchers/test_merge_request_args.py` (default + 4 literals + 2 bool cases). Confirmed RED before the fix (the raw strings leaked through) and GREEN after. Also fed each resolved value through curl_cffi's exact `FOLLOWLOCATION`-setting path; all set without `ValueError`.

## Behavior note
Unknown/typo `follow_redirects` strings now fall back to `CurlFollow.SAFE` instead of raising the previous (incidental) `ValueError: invalid literal for int()`. Since `FollowRedirects` is a `Literal` type, type-checked callers can't hit this; the fallback just makes the runtime robust across curl_cffi versions. Happy to switch to an explicit raise on unknown strings if you prefer fail-loud.

Targeted at `dev` per CONTRIBUTING. `ruff check` + `ruff format --check` clean; `pytest tests/fetchers/test_merge_request_args.py` 12/12 pass on `dev`.

Submitted by @Brentbin; AI-assisted with Claude Code and reviewed before submission.