### PR TITLE
fix: keep init scripts available to page actions

### DIFF
--- a/scrapling/engines/_browsers/_base.py
+++ b/scrapling/engines/_browsers/_base.py
@@ -1,7 +1,9 @@
 from time import time
 from re import search as re_search
+from json import dumps as json_dumps
 from asyncio import sleep as asyncio_sleep, Lock
 from contextlib import contextmanager, asynccontextmanager
+from pathlib import Path
 
 from playwright.sync_api._generated import Page
 from playwright.sync_api import (
@@ -43,6 +45,41 @@ from scrapling.core._types import (
     AsyncGenerator,
 )
 from scrapling.engines.constants import STEALTH_ARGS, HARMFUL_ARGS, DEFAULT_ARGS
+
+
+__INIT_SCRIPT_MARKER__ = "__scrapling_init_scripts__"
+
+
+def _get_init_script_key(init_script: str) -> str:
+    """Return a stable key for an init script path."""
+    return str(Path(init_script).resolve())
+
+
+def _get_init_script_source(init_script: str) -> tuple[str, str]:
+    """Return a stable key and source for an init script path."""
+    path = Path(init_script).resolve()
+    return str(path), path.read_text(encoding="utf-8")
+
+
+def _get_init_script_marker(init_script: str) -> str:
+    """Return a marker script used to detect whether context init scripts ran."""
+    key = _get_init_script_key(init_script)
+    return (
+        f"globalThis.{__INIT_SCRIPT_MARKER__} = globalThis.{__INIT_SCRIPT_MARKER__} || {{}};\n"
+        f"globalThis.{__INIT_SCRIPT_MARKER__}[{json_dumps(key)}] = true;"
+    )
+
+
+__INIT_SCRIPT_FALLBACK__ = f"""
+(payload) => {{
+    const [key, source] = payload;
+    globalThis.{__INIT_SCRIPT_MARKER__} = globalThis.{__INIT_SCRIPT_MARKER__} || {{}};
+    if (!globalThis.{__INIT_SCRIPT_MARKER__}[key]) {{
+        (0, eval)(source);
+        globalThis.{__INIT_SCRIPT_MARKER__}[key] = true;
+    }}
+}}
+"""
 
 
 class SyncSession:
@@ -93,11 +130,17 @@ class SyncSession:
         """Initialize the browser context."""
         if config.init_script:
             ctx.add_init_script(path=config.init_script)
+            ctx.add_init_script(script=_get_init_script_marker(config.init_script))
 
         if config.cookies:  # pragma: no cover
             ctx.add_cookies(config.cookies)
 
         return ctx
+
+    def _apply_init_script_fallback(self, page: Page) -> None:
+        """Apply init_script to the current page if context-level injection did not run."""
+        if self._config.init_script:
+            page.evaluate(__INIT_SCRIPT_FALLBACK__, _get_init_script_source(self._config.init_script))
 
     def _get_page(
         self,
@@ -266,11 +309,17 @@ class AsyncSession:
         """Initialize the browser context."""
         if config.init_script:  # pragma: no cover
             await ctx.add_init_script(path=config.init_script)
+            await ctx.add_init_script(script=_get_init_script_marker(config.init_script))
 
         if config.cookies:  # pragma: no cover
             await ctx.add_cookies(config.cookies)
 
         return ctx
+
+    async def _apply_init_script_fallback(self, page: AsyncPage) -> None:
+        """Apply init_script to the current page if context-level injection did not run."""
+        if self._config.init_script:
+            await page.evaluate(__INIT_SCRIPT_FALLBACK__, _get_init_script_source(self._config.init_script))
 
     async def _get_page(
         self,

--- a/scrapling/engines/_browsers/_controllers.py
+++ b/scrapling/engines/_browsers/_controllers.py
@@ -167,6 +167,8 @@ class DynamicSession(SyncSession, DynamicSessionMixin):
                     if not first_response:
                         raise RuntimeError(f"Failed to get response for {url}")
 
+                    self._apply_init_script_fallback(page)
+
                     if params.page_action:
                         try:
                             _ = params.page_action(page)
@@ -355,6 +357,8 @@ class AsyncDynamicSession(AsyncSession, DynamicSessionMixin):
 
                     if not first_response:
                         raise RuntimeError(f"Failed to get response for {url}")
+
+                    await self._apply_init_script_fallback(page)
 
                     if params.page_action:
                         try:

--- a/scrapling/engines/_browsers/_stealth.py
+++ b/scrapling/engines/_browsers/_stealth.py
@@ -250,6 +250,8 @@ class StealthySession(SyncSession, StealthySessionMixin):
                     if not first_response:
                         raise RuntimeError(f"Failed to get response for {url}")
 
+                    self._apply_init_script_fallback(page)
+
                     if params.solve_cloudflare:
                         self._cloudflare_solver(page)
                         # Make sure the page is fully loaded after the captcha
@@ -525,6 +527,8 @@ class AsyncStealthySession(AsyncSession, StealthySessionMixin):
 
                     if not first_response:
                         raise RuntimeError(f"Failed to get response for {url}")
+
+                    await self._apply_init_script_fallback(page)
 
                     if params.solve_cloudflare:
                         await self._cloudflare_solver(page)

--- a/tests/fetchers/async/test_stealth_session.py
+++ b/tests/fetchers/async/test_stealth_session.py
@@ -1,6 +1,7 @@
 
 import pytest
 import asyncio
+from pathlib import Path
 
 import pytest_httpbin
 
@@ -77,6 +78,29 @@ class TestAsyncStealthySession:
         ) as session:
             response = await session.fetch(urls["html"])
             assert response.status == 200
+
+    async def test_init_script_is_available_in_page_action(self, urls, tmp_path):
+        """Test init_script state is visible to page_action callbacks."""
+        script_path = tmp_path / "init.js"
+        script_path.write_text(
+            "window.calculateSum = function(a, b) { return a + b; };",
+            encoding="utf-8",
+        )
+        results = []
+
+        async def check_init_script(page):
+            results.append(await page.evaluate("() => window.calculateSum?.(1, 1)"))
+
+        async with AsyncStealthySession(
+            init_script=str(Path(script_path).resolve()),
+            page_action=check_init_script,
+            google_search=False,
+            retries=1,
+        ) as session:
+            response = await session.fetch(urls["html"])
+
+        assert response.status == 200
+        assert results == [2]
 
     async def test_error_handling_in_fetch(self, urls):
         """Test error handling during fetch"""


### PR DESCRIPTION
## Summary
- preserve normal context-level `init_script` registration
- add a marker to detect when the browser backend did not run the init script
- apply the configured init script before `page_action` only when the marker is missing
- add an async stealth regression test for issue #350

## Tests
```bash
python -m compileall -q scrapling/engines/_browsers tests/fetchers/async/test_stealth_session.py
pytest tests/fetchers/async/test_stealth_session.py tests/fetchers/sync/test_stealth_session.py tests/fetchers/async/test_dynamic_session.py tests/fetchers/sync/test_dynamic.py -q
```

Result:

```text
19 passed
```

Also verified the original issue shape against `https://example.com`, where `page_action` observed `seen [2]`.

Fixes #350