### PR TITLE
Fix Playwright page content encoding

### DIFF
--- a/scrapling/engines/toolbelt/convertor.py
+++ b/scrapling/engines/toolbelt/convertor.py
@@ -122,6 +122,7 @@ class ResponseFactory:
         try:
             if page and "html" in final_response.all_headers().get("content-type", ""):
                 page_content = cls._get_page_content(page).encode("utf-8")
+                encoding = "utf-8"
             else:
                 page_content = final_response.body()
         except Exception as e:  # pragma: no cover
@@ -269,6 +270,7 @@ class ResponseFactory:
         try:
             if page and "html" in (await final_response.all_headers()).get("content-type", ""):
                 page_content = (await cls._get_async_page_content(page)).encode("utf-8")
+                encoding = "utf-8"
             else:
                 page_content = await final_response.body()
         except Exception as e:  # pragma: no cover

--- a/tests/fetchers/test_response_handling.py
+++ b/tests/fetchers/test_response_handling.py
@@ -1,7 +1,55 @@
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
+
+import pytest
 
 from scrapling.parser import Selector
 from scrapling.engines.toolbelt.convertor import ResponseFactory, Response
+
+
+HTML_WITH_ACCENTED_TEXT = "<html><body>Bürger</body></html>"
+LATIN9_CONTENT_TYPE = "text/html; charset=iso-8859-15"
+
+
+def make_sync_playwright_response():
+    response = Mock()
+    response.url = "https://example.com"
+    response.status = 200
+    response.status_text = "OK"
+    response.headers = {"content-type": LATIN9_CONTENT_TYPE}
+    response.all_headers = Mock(return_value={"content-type": LATIN9_CONTENT_TYPE})
+    response.body = Mock(return_value=HTML_WITH_ACCENTED_TEXT.encode("iso-8859-15"))
+    response.request.all_headers = Mock(return_value={})
+    response.request.redirected_from = None
+    return response
+
+
+def make_sync_page():
+    page = Mock()
+    page.url = "https://example.com"
+    page.content = Mock(return_value=HTML_WITH_ACCENTED_TEXT)
+    page.context.cookies = Mock(return_value=[])
+    return page
+
+
+def make_async_playwright_response():
+    response = Mock()
+    response.url = "https://example.com"
+    response.status = 200
+    response.status_text = "OK"
+    response.headers = {"content-type": LATIN9_CONTENT_TYPE}
+    response.all_headers = AsyncMock(return_value={"content-type": LATIN9_CONTENT_TYPE})
+    response.body = AsyncMock(return_value=HTML_WITH_ACCENTED_TEXT.encode("iso-8859-15"))
+    response.request.all_headers = AsyncMock(return_value={})
+    response.request.redirected_from = None
+    return response
+
+
+def make_async_page():
+    page = Mock()
+    page.url = "https://example.com"
+    page.content = AsyncMock(return_value=HTML_WITH_ACCENTED_TEXT)
+    page.context.cookies = AsyncMock(return_value=[])
+    return page
 
 
 class TestResponseFactory:
@@ -30,6 +78,72 @@ class TestResponseFactory:
         assert response.status == 200
         assert response.url == "https://example.com"
         assert isinstance(response, Response)
+
+    def test_playwright_page_content_uses_utf8_encoding(self):
+        """page.content() returns Unicode, so its encoded bytes are UTF-8."""
+        mock_response = make_sync_playwright_response()
+        mock_page = make_sync_page()
+
+        response = ResponseFactory.from_playwright_response(
+            mock_page,
+            mock_response,
+            mock_response,
+            {"adaptive": False},
+            collect_history=False,
+        )
+
+        assert response.encoding == "utf-8"
+        assert "Bürger" in response.html_content
+        assert "BÃ" not in response.html_content
+
+    def test_playwright_raw_response_keeps_header_encoding(self):
+        """Raw response bytes should still use the charset from Content-Type."""
+        mock_response = make_sync_playwright_response()
+
+        response = ResponseFactory.from_playwright_response(
+            None,
+            mock_response,
+            mock_response,
+            {"adaptive": False},
+            collect_history=False,
+        )
+
+        assert response.encoding == "iso-8859-15"
+        assert "Bürger" in response.html_content
+
+    @pytest.mark.asyncio
+    async def test_async_playwright_page_content_uses_utf8_encoding(self):
+        """Async page.content() returns Unicode, so its encoded bytes are UTF-8."""
+        mock_response = make_async_playwright_response()
+        mock_page = make_async_page()
+
+        response = await ResponseFactory.from_async_playwright_response(
+            mock_page,
+            mock_response,
+            mock_response,
+            {"adaptive": False},
+            collect_history=False,
+        )
+
+        assert response.encoding == "utf-8"
+        assert "Bürger" in response.html_content
+        assert "BÃ" not in response.html_content
+
+    @pytest.mark.asyncio
+    async def test_async_playwright_raw_response_keeps_header_encoding(self):
+        """Raw response bytes should still use the charset from Content-Type."""
+        mock_response = make_async_playwright_response()
+
+        response = await ResponseFactory.from_async_playwright_response(
+            None,
+            mock_response,
+            mock_response,
+            {"adaptive": False},
+            collect_history=False,
+        )
+
+        assert response.encoding == "iso-8859-15"
+        assert "Bürger" in response.html_content
 
     def test_response_history_processing(self):
         """Test processing response history"""


### PR DESCRIPTION
## Summary

- Set browser `page.content()` responses to `utf-8` after encoding the browser-decoded Unicode HTML.
- Keep the server-provided `Content-Type` charset for raw `final_response.body()` fallback responses.
- Add sync and async regression coverage for non-UTF-8 headers with accented text.

Fixes #364.

## Tests

- `.venv/bin/python -m pytest tests/fetchers/test_response_handling.py`
- `.venv/bin/python -m pytest tests/parser/test_general.py`
