### PR TITLE
feat: support custom browser executable in CLI

### DIFF
--- a/scrapling/cli.py
+++ b/scrapling/cli.py
@@ -267,6 +267,11 @@ def _common_browser_options(f):
     """Apply shared Click options for browser-based commands (fetch/stealthy_fetch)."""
     decorators = [
         option(
+            "--executable-path",
+            envvar="SCRAPLING_EXECUTABLE_PATH",
+            help="Path to a custom Chromium-compatible browser executable. Can also be set with SCRAPLING_EXECUTABLE_PATH.",
+        ),
+        option(
             "--ai-targeted",
             is_flag=True,
             default=False,
@@ -563,6 +568,7 @@ def fetch(
     ai_targeted,
     dns_over_https,
     block_ads,
+    executable_path,
 ):
     """Opens up a browser and fetch content using DynamicFetcher."""
     parsed_headers, _ = _ParseHeaders(extra_headers, False)
@@ -580,6 +586,8 @@ def fetch(
         dns_over_https,
         block_ads,
     )
+    if executable_path:
+        kwargs["executable_path"] = executable_path
     from scrapling.fetchers import DynamicFetcher
 
     __Request_and_Save(DynamicFetcher.fetch, url, output_file, css_selector, ai_targeted=ai_targeted, **kwargs)
@@ -626,6 +634,7 @@ def stealthy_fetch(
     ai_targeted,
     dns_over_https,
     block_ads,
+    executable_path,
 ):
     """Opens up a browser with advanced stealth features and fetch content using StealthyFetcher."""
     parsed_headers, _ = _ParseHeaders(extra_headers, False)
@@ -643,6 +652,8 @@ def stealthy_fetch(
         dns_over_https,
         block_ads,
     )
+    if executable_path:
+        kwargs["executable_path"] = executable_path
     kwargs.update(
         {
             "block_webrtc": block_webrtc,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,4 +1,6 @@
 import pytest
+import sys
+from types import ModuleType
 from click.testing import CliRunner
 from unittest.mock import patch, MagicMock
 import pytest_httpbin
@@ -178,6 +180,39 @@ class TestCLI:
                 ]
             )
             assert result.exit_code == 0
+
+    def test_extract_fetch_passes_executable_path(self, runner, tmp_path, html_url):
+        output_file = tmp_path / "output.txt"
+
+        fetchers = ModuleType('scrapling.fetchers')
+        fetchers.DynamicFetcher = MagicMock()
+        fetchers.DynamicFetcher.fetch.return_value = configure_selector_mock()
+        with patch.dict(sys.modules, {'scrapling.fetchers': fetchers}):
+
+            result = runner.invoke(
+                fetch,
+                [html_url, str(output_file), '--executable-path', '/opt/custom-chromium'],
+            )
+
+            assert result.exit_code == 0
+            assert fetchers.DynamicFetcher.fetch.call_args.kwargs['executable_path'] == '/opt/custom-chromium'
+
+    def test_extract_stealthy_fetch_uses_executable_path_env(self, runner, tmp_path, html_url):
+        output_file = tmp_path / "output.md"
+
+        fetchers = ModuleType('scrapling.fetchers')
+        fetchers.StealthyFetcher = MagicMock()
+        fetchers.StealthyFetcher.fetch.return_value = configure_selector_mock()
+        with patch.dict(sys.modules, {'scrapling.fetchers': fetchers}):
+
+            result = runner.invoke(
+                stealthy_fetch,
+                [html_url, str(output_file)],
+                env={'SCRAPLING_EXECUTABLE_PATH': '/opt/env-chromium'},
+            )
+
+            assert result.exit_code == 0
+            assert fetchers.StealthyFetcher.fetch.call_args.kwargs['executable_path'] == '/opt/env-chromium'
 
     def test_extract_stealthy_fetch_command(self, runner, tmp_path, html_url):
         """Test extract fetch command"""


### PR DESCRIPTION
## Summary

- add `--executable-path` to the browser-backed `extract fetch` and `extract stealthy-fetch` commands
- use `SCRAPLING_EXECUTABLE_PATH` as the Click environment-variable fallback
- pass the resolved path through to `DynamicFetcher` and `StealthyFetcher`

Closes #371.

## Validation

- `python -m pytest tests/cli/test_cli.py::TestCLI::test_extract_fetch_passes_executable_path tests/cli/test_cli.py::TestCLI::test_extract_stealthy_fetch_uses_executable_path_env -q --basetemp .pytest-tmp`
- `python -m ruff check scrapling/cli.py tests/cli/test_cli.py`
- `git diff --check`