### PR TITLE
fix(spiders): preserve cookies for browser-engine responses in cache

### DIFF
--- a/scrapling/spiders/cache.py
+++ b/scrapling/spiders/cache.py
@@ -6,7 +6,7 @@ import anyio
 from anyio import Path as AsyncPath
 
 from scrapling.core.utils import log
-from scrapling.core._types import Dict, Optional, Any
+from scrapling.core._types import Dict, Optional, Any, Tuple
 from scrapling.engines.toolbelt.custom import Response
 
 
@@ -28,13 +28,21 @@ class ResponseCacheManager:
             async with await anyio.open_file(path, "rb") as f:
                 data: Dict[str, Any] = orjson.loads(await f.read())
 
+            # Browser-engine cookies are cached as a JSON array (see `put`) and come back
+            # as a `list`; restore the `tuple` shape `Response` expects. Static-engine
+            # cookies are cached as a JSON object and come back as a `dict` already.
+            cached_cookies = data["cookies"]
+            cookies: Tuple[Dict[str, str], ...] | Dict[str, str] = (
+                tuple(cached_cookies) if isinstance(cached_cookies, list) else cached_cookies
+            )
+
             return Response(
                 url=data["url"],
                 content=b64decode(data["content"]),
                 status=data["status"],
                 reason=data["reason"],
                 encoding=data["encoding"],
-                cookies=data["cookies"],
+                cookies=cookies,
                 headers=data["headers"],
                 request_headers=data["request_headers"],
                 method=data["method"],
@@ -55,7 +63,13 @@ class ResponseCacheManager:
                     "status": response.status,
                     "reason": response.reason,
                     "encoding": response.encoding,
-                    "cookies": dict(response.cookies) if isinstance(response.cookies, dict) else {},
+                    # Browser-engine responses store cookies as a `tuple` of full cookie
+                    # dicts; static-engine responses store a flat `dict`. Preserve whichever
+                    # shape it is instead of collapsing non-dict cookies to `{}`, which was
+                    # silently dropping every cookie from browser-engine responses.
+                    "cookies": list(response.cookies)
+                    if isinstance(response.cookies, tuple)
+                    else dict(response.cookies),
                     "headers": dict(response.headers),
                     "request_headers": dict(response.request_headers),
                     "method": method,

--- a/tests/spiders/test_cache.py
+++ b/tests/spiders/test_cache.py
@@ -14,14 +14,19 @@ from scrapling.engines.toolbelt.custom import Response
 from scrapling.core._types import Any, Dict, Set, AsyncGenerator
 
 
-def _make_response(url: str = "https://example.com", body: bytes = b"<html>hello</html>", status: int = 200) -> Response:
+def _make_response(
+    url: str = "https://example.com",
+    body: bytes = b"<html>hello</html>",
+    status: int = 200,
+    cookies: Any = None,
+) -> Response:
     return Response(
         url=url,
         content=body,
         status=status,
         reason="OK",
         encoding="utf-8",
-        cookies={},
+        cookies={} if cookies is None else cookies,
         headers={"content-type": "text/html"},
         request_headers={"user-agent": "test"},
         method="GET",
@@ -48,6 +53,66 @@ class TestResponseCacheManager:
             assert restored.encoding == original.encoding
             assert dict(restored.headers) == dict(original.headers)
             assert dict(restored.request_headers) == dict(original.request_headers)
+
+    @pytest.mark.anyio
+    async def test_put_get_roundtrip_preserves_browser_engine_cookies(self):
+        """Regression test for #376.
+
+        Browser engines (Playwright) populate ``Response.cookies`` as a ``tuple`` of
+        full cookie dicts (see ``engines/toolbelt/convertor.py``), unlike the flat
+        ``dict`` the static engine uses. The cache previously only recognized the
+        ``dict`` shape and silently discarded any other cookies, so a cached
+        browser-engine response replayed with no cookies at all.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = ResponseCacheManager(tmpdir)
+            fp = b"\x06" * 20
+            browser_cookies = (
+                {
+                    "name": "session",
+                    "value": "abc123",
+                    "domain": "example.com",
+                    "path": "/",
+                    "expires": -1,
+                    "httpOnly": True,
+                    "secure": True,
+                    "sameSite": "Lax",
+                },
+                {
+                    "name": "csrftoken",
+                    "value": "xyz789",
+                    "domain": "example.com",
+                    "path": "/",
+                    "expires": -1,
+                    "httpOnly": False,
+                    "secure": True,
+                    "sameSite": "Strict",
+                },
+            )
+            original = _make_response(cookies=browser_cookies)
+
+            await cache.put(fp, original, "GET")
+            restored = await cache.get(fp)
+
+            assert restored is not None
+            assert restored.cookies == browser_cookies
+            assert isinstance(restored.cookies, tuple)
+
+    @pytest.mark.anyio
+    async def test_put_get_roundtrip_preserves_static_engine_cookies(self):
+        """Flat-dict cookies (static engine) must still round-trip as a ``dict``."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = ResponseCacheManager(tmpdir)
+            fp = b"\x07" * 20
+            static_cookies = {"session": "abc123", "csrftoken": "xyz789"}
+            original = _make_response(cookies=static_cookies)
+
+            await cache.put(fp, original, "GET")
+            restored = await cache.get(fp)
+
+            assert restored is not None
+            assert restored.cookies == static_cookies
+            assert isinstance(restored.cookies, dict)
 
     @pytest.mark.anyio
     async def test_put_overwrites_existing_entry(self):


### PR DESCRIPTION
Fixes #376

## Root cause

`Response.cookies` has two possible shapes (`scrapling/engines/toolbelt/custom.py:48`):

- Static engine: a flat `dict` (`convertor.py:317`)
- Browser engines, sync and async (Playwright): a `tuple` of full cookie dicts (`convertor.py:139`, `convertor.py:287`)

`ResponseCacheManager.put()` only handled the `dict` case:

```python
"cookies": dict(response.cookies) if isinstance(response.cookies, dict) else {},
```

Any browser-engine response has `tuple` cookies, so `isinstance(..., dict)` is `False` and the `else {}` branch discards every cookie before it's ever written to the cache file. `get()` then rebuilds the `Response` with `cookies={}`, so a replayed browser-engine response has no cookies at all — this silently breaks anything downstream relying on cookies (sessions, auth, CSRF tokens).

## Fix

Preserve whichever shape the cookies are in, instead of collapsing non-dict cookies to `{}`:

- `put()`: serialize a `tuple` as a JSON array (`list(response.cookies)`) and a `dict` as a JSON object (`dict(response.cookies)`).
- `get()`: JSON arrays deserialize back as `list`, so restore the `tuple` shape `Response.__init__` expects; JSON objects already come back as `dict`.

This keeps the round-trip shape-preserving rather than normalizing everything to a flat dict, so code that depends on the tuple-of-full-cookie-dicts shape for browser-engine responses (domain, path, expiry, etc.) still gets that shape back after a cache replay.

## Tests

Added two regression tests to `tests/spiders/test_cache.py`:

- `test_put_get_roundtrip_preserves_browser_engine_cookies` — tuple-of-dicts cookies (the browser-engine shape) survive `put()`/`get()` unchanged. This fails on `main`/`dev` before the fix (`assert {} == (...)`) and passes after.
- `test_put_get_roundtrip_preserves_static_engine_cookies` — flat-dict cookies (the static-engine shape) still round-trip correctly, confirming no regression for the existing working case.

```
tests/spiders/test_cache.py::TestResponseCacheManager::test_put_get_roundtrip_preserves_browser_engine_cookies PASSED
tests/spiders/test_cache.py::TestResponseCacheManager::test_put_get_roundtrip_preserves_static_engine_cookies PASSED
```

Full `tests/spiders/test_cache.py` suite (12 tests) passes. `ruff check`, `ruff format --check`, `mypy`, `pyright`, and `bandit` all pass clean on the changed file. Ran the broader non-browser test suite (`pytest tests/ -k "not (DynamicFetcher or StealthyFetcher)"`, 738 passed) to confirm no regressions elsewhere — the only failures were pre-existing, unrelated tests failing due to missing local Playwright browser binaries.

Credit to @truongsontung for the initial diagnosis in the issue thread — I independently confirmed the same root cause and landed on a slightly different fix (shape-preserving round-trip rather than always flattening to a dict on read) to avoid changing the cookie shape browser-engine consumers see after a cache replay.
