### PR TITLE
fix: stop the MCP screenshot tool from sending the image twice

### DIFF
--- a/scrapling/core/ai.py
+++ b/scrapling/core/ai.py
@@ -930,6 +930,14 @@ class ScraplingMCPServer:
             description=self.bulk_stealthy_fetch.__doc__,
             structured_output=True,
         )
-        # Screenshot tool (returns image + url content blocks, not structured JSON)
-        server.add_tool(self.screenshot, title="screenshot", description=self.screenshot.__doc__)
+        # Screenshot tool (returns image + url content blocks, not structured JSON).
+        # `structured_output` must be explicitly False: the default (None) still derives
+        # an output schema from the return annotation, which serializes the image a
+        # second time into `structuredContent`.
+        server.add_tool(
+            self.screenshot,
+            title="screenshot",
+            description=self.screenshot.__doc__,
+            structured_output=False,
+        )
         server.run(transport="stdio" if not http else "streamable-http")

--- a/tests/ai/test_ai_mcp.py
+++ b/tests/ai/test_ai_mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import struct
 from typing import Any
@@ -7,6 +8,7 @@ from threading import Thread
 
 import pytest
 import pytest_httpbin
+from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent
 
 from scrapling.parser import Selector
@@ -448,3 +450,35 @@ class TestNormalizeCredentials:
     def test_missing_username_raises(self):
         with pytest.raises(ValueError, match="username"):
             _normalize_credentials({"password": "pass"})
+
+
+class TestToolRegistration:
+    """Test how tools are registered on the MCP server"""
+
+    @staticmethod
+    def _registered_tools(monkeypatch) -> dict:
+        captured: dict = {}
+
+        def _capture(self, transport: str = "stdio") -> None:
+            captured["server"] = self
+
+        monkeypatch.setattr(FastMCP, "run", _capture)
+        ScraplingMCPServer().serve(http=False, host="127.0.0.1", port=0)
+        tools = asyncio.run(captured["server"].list_tools())
+        return {tool.name: tool for tool in tools}
+
+    def test_screenshot_tool_has_no_output_schema(self, monkeypatch):
+        """The screenshot tool returns content blocks, so it must not declare an output
+        schema. With one, FastMCP serializes the return value into `structuredContent`
+        as well, and the base64 image is sent twice — once as an image block and once as
+        JSON text, which is enormously expensive in an LLM's context window."""
+        tools = self._registered_tools(monkeypatch)
+
+        assert tools["screenshot"].outputSchema is None
+
+    def test_data_tools_keep_their_output_schema(self, monkeypatch):
+        """Tools returning models still expose structured output"""
+        tools = self._registered_tools(monkeypatch)
+
+        assert tools["get"].outputSchema is not None
+        assert tools["open_session"].outputSchema is not None


### PR DESCRIPTION
## Proposed change

The MCP `screenshot` tool returns its image twice — once as an `ImageContent`
block and once again, base64 and all, inside `structuredContent`.

`serve()` registers it without `structured_output`:

```python
# Screenshot tool (returns image + url content blocks, not structured JSON)
server.add_tool(self.screenshot, title="screenshot", description=self.screenshot.__doc__)
```

The comment says the intent, but the default `structured_output=None` is not
"off" — it means "derive a schema from the return annotation". Since
`List[ImageContent | TextContent]` is serializable, `func_metadata` builds an
output model and FastMCP serializes the return value into `structuredContent`
in addition to the content blocks. Only `structured_output=False` skips it.

This is invisible over the wire but expensive for LLM clients, which surface
`structuredContent` as an extra text block. Measured against a 545 KB PNG
screenshot through an Anthropic-compatible endpoint:

| what was sent | input tokens |
|---|---|
| image block only | **1,443** |
| full tool result as the client assembles it | **63,466** |

In our case three screenshots in one agent session added ~190k tokens and blew
the model's context window. Truncation guards do not save you here: the client
truncated the duplicate to its "25,000 token" limit, but its estimate for
base64 is off by roughly 2.5x, so ~62k tokens still went through.

After the fix, the tool result is just the image block plus the URL text block,
and `structuredContent` is `None`. Verified end to end against a live stdio MCP
server, not only in the unit test.

### Type of change:

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information

- This PR fixes or closes an issue: fixes #
- This PR is related to an issue: #
- Link to documentation pull request: **

The two added tests capture `serve()`'s registration by patching `FastMCP.run`,
then assert over the registered tools: `screenshot` must expose no output
schema, while `get` and `open_session` keep theirs. Without the one-line fix the
first test fails with the generated `screenshotOutput` schema.

`ruff check` and `ruff format --check` report the same single pre-existing E402
in `tests/ai/test_ai_mcp.py` before and after this change; I left that line
alone to keep the diff minimal.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.