### PR TITLE
fix: default browser locale to system setting

### DIFF
--- a/scrapling/engines/_browsers/_validators.py
+++ b/scrapling/engines/_browsers/_validators.py
@@ -1,3 +1,4 @@
+import locale
 from pathlib import Path
 from typing import Annotated
 from functools import lru_cache
@@ -95,6 +96,10 @@ class PlaywrightConfig(Struct, kw_only=True, frozen=False, weakref=True):
 
     def __post_init__(self):  # pragma: no cover
         """Custom validation after msgspec validation"""
+        if self.locale is None:
+            system_locale = locale.getlocale()[0]
+            if system_locale:
+                self.locale = system_locale.replace("_", "-")
         if self.page_action and not callable(self.page_action):
             raise TypeError(f"page_action must be callable, got {type(self.page_action).__name__}")
         if self.page_setup and not callable(self.page_setup):

--- a/tests/fetchers/test_validator.py
+++ b/tests/fetchers/test_validator.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 import pytest
+
 from scrapling.engines._browsers._validators import (
     validate,
     StealthConfig,
@@ -24,6 +27,20 @@ class TestValidators:
         assert config.headless is True
         assert config.timeout == 30000
         assert isinstance(config.proxy, dict)
+
+    def test_playwright_config_defaults_to_system_locale(self):
+        """Test the system locale is normalized for Playwright."""
+        with patch("locale.getlocale", return_value=("pt_BR", "UTF-8")):
+            config = validate({}, PlaywrightConfig)
+
+        assert config.locale == "pt-BR"
+
+    def test_playwright_config_preserves_explicit_locale(self):
+        """Test an explicit locale takes precedence over the system locale."""
+        with patch("locale.getlocale", return_value=("pt_BR", "UTF-8")):
+            config = validate({"locale": "de-DE"}, PlaywrightConfig)
+
+        assert config.locale == "de-DE"
 
     def test_playwright_config_invalid_max_pages(self):
         """Test PlaywrightConfig with invalid max_pages"""


### PR DESCRIPTION
## Proposed change

When no locale is provided, resolve the host locale and normalize underscores to Playwright's BCP 47-style format. Explicit locale values remain unchanged.

### Type of change:

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information

- This PR fixes or closes an issue: fixes #381
- This PR is related to an issue: #381
- Link to documentation pull request: N/A

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.
