### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <!-- mcp-name: io.github.D4Vinci/Scrapling -->
 
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-d4vinci-scrapling)](https://mcpindex.ai/server/io-github-d4vinci-scrapling)
+
+
 <h1 align="center">
     <a href="https://scrapling.readthedocs.io">
         <picture>


### PR DESCRIPTION
Hey, Scrapling's MCP server came back clean on mcpindex's description-level screen (checks for injection/manipulation patterns in the tool description, nothing deeper). Added the badge here in case it's useful. Totally fine to close if not, no hard feelings.