### PR TITLE
ci(docker): tag images with the release version on merge

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     permissions:
       contents: read
       packages: write
@@ -26,6 +27,19 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+
+    - name: Extract release version from PR title
+      id: version
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        if [[ $PR_TITLE =~ ^v ]]; then
+          echo "version=$PR_TITLE" >> "$GITHUB_OUTPUT"
+          echo "Release version detected from PR title: $PR_TITLE"
+        else
+          echo "PR title '$PR_TITLE' is not a version; skipping semver tags."
+        fi
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -56,9 +70,8 @@ jobs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
+          type=semver,pattern={{version}},value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }},enable=${{ steps.version.outputs.version != '' }}
           type=raw,value=latest,enable={{is_default_branch}}
         labels: |
           org.opencontainers.image.title=Scrapling
@@ -70,6 +83,7 @@ jobs:
           org.opencontainers.image.documentation=https://scrapling.readthedocs.io/en/latest/
 
     - name: Build and push Docker image
+      id: build
       uses: docker/build-push-action@v6
       with:
         context: .


### PR DESCRIPTION
## Proposed change

Published Docker images never receive the release version — only `latest` / `main` (from a manual `workflow_dispatch`) and `pr-N`. The `type=semver` rules in `docker-build.yml` never activate, because the workflow runs on `pull_request: closed` / `workflow_dispatch` — never on a tag ref — so `docker/metadata-action`'s semver logic (which requires `refs/tags/*`) is effectively dead, and released versions (`vX.Y.Z`) are never applied to an image.

Triggering the docker build on a `release` / `push tag` event would not work either: the tag/release is created by `github-actions[bot]` using the default `GITHUB_TOKEN`, and GitHub does not start new workflow runs from `GITHUB_TOKEN`-raised events.

Instead, this PR derives the version from the merged PR title — the same source `release-and-publish.yml` already uses — and passes it to `docker/metadata-action` via `value=`, so the semver rules emit the version on the same merge event that creates the release. Purely additive; manual dispatch is unchanged.

**Changes (all in `.github/workflows/docker-build.yml`):**

- **Extract the version from the merged PR title** in a new step, exposed as `steps.version.outputs.version` (set only on a merged `pull_request` whose title starts with `v`). The title is read through an `env:` variable instead of being inlined into the `run:` script, to avoid shell script injection from an attacker-controlled PR title.
- **Rewire the semver tags** to use that value:
  - `type=semver,pattern={{version}},value=…,enable=…` → `X.Y.Z`
  - `type=semver,pattern={{major}}.{{minor}},value=…,enable=…` → `X.Y`
  - `latest` is added automatically by `docker/metadata-action` for non-pre-release semver.
  - The `{{major}}` tag is intentionally dropped: for a `0.y.z` version it would push a bare `0` tag that slides across every `0.x` release.
  - The `enable=` guards make manual dispatch / non-version merges skip the semver lines cleanly (no warnings).
- **Gate the job** with `if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true`, so it no longer builds/pushes on closed-but-unmerged PRs.
- **Add `id: build`** to the build-push step so the existing "Image digest" step prints the real digest instead of an empty string.

**Resulting tags**

| Event | Before | After |
|---|---|---|
| Merge PR `vX.Y.Z` | `pr-N` only | `X.Y.Z`, `X.Y`, `latest` (+ `pr-N`) |
| `workflow_dispatch` on `main` | `main`, `latest` | unchanged |
| PR closed without merge | builds `pr-N` | job skipped |

**Testing**

- `actionlint` passes clean on the workflow.
- Unit-tested the version-extraction logic against real and synthetic PR titles, including a script-injection payload (confirmed the title is handled as literal data, no command execution).
- Verified the `value=` override, `{{major}}.{{minor}}` output, automatic `latest`, and `enable=` gating against `docker/metadata-action` source and README.

### Type of change:
<!--
  What type of change does your PR introduce to Scrapling?
  NOTE: Please, check at least 1 box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->



- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes an issue: fixes #
- This PR is related to an issue: #
- Link to documentation pull request: **

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [ ] All new Python files are placed inside an existing directory. <!-- N/A: workflow-only change, no Python files added -->
* [ ] All filenames are in all lowercase characters with no spaces or dashes.
* [ ] All functions and variable names follow Python naming conventions. <!-- N/A: no Python code changed -->
* [ ] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html). <!-- N/A -->
* [ ] All functions have doc-strings. <!-- N/A -->
