### PR TITLE
fix(spiders): preserve browser-engine cookies in the response cache

### DIFF
--- a/scrapling/spiders/cache.py
+++ b/scrapling/spiders/cache.py
@@ -10,6 +10,25 @@ from scrapling.core._types import Dict, Optional, Any
 from scrapling.engines.toolbelt.custom import Response
 
 
+def _serialize_cookies(cookies: Any) -> Any:
+    """Return a JSON-serializable form of ``Response.cookies``.
+
+    Static-engine responses carry a flat ``dict``; browser-engine responses
+    carry a tuple of full cookie dicts. Both shapes are preserved as-is so the
+    replayed response is identical to the original.
+    """
+    if isinstance(cookies, dict):
+        return dict(cookies)
+    if isinstance(cookies, (tuple, list)):
+        return [dict(cookie) for cookie in cookies]
+    return {}
+
+
+def _deserialize_cookies(cookies: Any) -> Any:
+    """Restore the original ``Response.cookies`` shape written by ``_serialize_cookies``."""
+    return tuple(cookies) if isinstance(cookies, list) else cookies
+
+
 class ResponseCacheManager:
     """Caches HTTP responses to disk for replay during spider development."""
 
@@ -34,7 +53,7 @@ class ResponseCacheManager:
                 status=data["status"],
                 reason=data["reason"],
                 encoding=data["encoding"],
-                cookies=data["cookies"],
+                cookies=_deserialize_cookies(data["cookies"]),
                 headers=data["headers"],
                 request_headers=data["request_headers"],
                 method=data["method"],
@@ -55,7 +74,7 @@ class ResponseCacheManager:
                     "status": response.status,
                     "reason": response.reason,
                     "encoding": response.encoding,
-                    "cookies": dict(response.cookies) if isinstance(response.cookies, dict) else {},
+                    "cookies": _serialize_cookies(response.cookies),
                     "headers": dict(response.headers),
                     "request_headers": dict(response.request_headers),
                     "method": method,

--- a/tests/spiders/test_cache.py
+++ b/tests/spiders/test_cache.py
@@ -14,14 +14,19 @@ from scrapling.engines.toolbelt.custom import Response
 from scrapling.core._types import Any, Dict, Set, AsyncGenerator
 
 
-def _make_response(url: str = "https://example.com", body: bytes = b"<html>hello</html>", status: int = 200) -> Response:
+def _make_response(
+    url: str = "https://example.com",
+    body: bytes = b"<html>hello</html>",
+    status: int = 200,
+    cookies: Any = None,
+) -> Response:
     return Response(
         url=url,
         content=body,
         status=status,
         reason="OK",
         encoding="utf-8",
-        cookies={},
+        cookies={} if cookies is None else cookies,
         headers={"content-type": "text/html"},
         request_headers={"user-agent": "test"},
         method="GET",
@@ -48,6 +53,29 @@ class TestResponseCacheManager:
             assert restored.encoding == original.encoding
             assert dict(restored.headers) == dict(original.headers)
             assert dict(restored.request_headers) == dict(original.request_headers)
+
+    @pytest.mark.anyio
+    async def test_roundtrip_preserves_cookies(self):
+        """Cookies must survive the cache round-trip for both engine shapes.
+
+        Browser-engine responses expose ``cookies`` as a tuple of full cookie
+        dicts, which the serializer used to discard entirely, so a replayed
+        response came back with no cookies at all.
+        """
+        browser_cookies = ({"name": "sid", "value": "abc", "domain": "example.com", "path": "/"},)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = ResponseCacheManager(tmpdir)
+            fp = b"\x07" * 20
+
+            await cache.put(fp, _make_response(cookies=browser_cookies), "GET")
+            restored = await cache.get(fp)
+            assert restored is not None
+            assert restored.cookies == browser_cookies
+
+            await cache.put(fp, _make_response(cookies={"sid": "abc"}), "GET")
+            restored = await cache.get(fp)
+            assert restored is not None
+            assert restored.cookies == {"sid": "abc"}
 
     @pytest.mark.anyio
     async def test_put_overwrites_existing_entry(self):


### PR DESCRIPTION
## Proposed change

`ResponseCacheManager.put` serialized cookies with `dict(response.cookies) if isinstance(response.cookies, dict) else {}`. Browser (Playwright) engine responses expose `cookies` as a tuple of full cookie dicts rather than a flat dict, so the `else` branch was taken and every cookie was dropped — the cached replay came back with `cookies={}`.

Cookies are now serialized through a helper that keeps both shapes (flat dict for the static engine, list of cookie dicts for the browser engines) and are restored to the original tuple shape on read, so a replayed response matches the original for both engines.

### Type of change:

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information

- This PR fixes or closes an issue: fixes #376
- This PR is related to an issue:
- Link to documentation pull request: **

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.
