### PR TITLE
fix: defer browser headers until session startup

### DIFF
--- a/scrapling/engines/_browsers/_base.py
+++ b/scrapling/engines/_browsers/_base.py
@@ -20,7 +20,7 @@ from playwright._impl._errors import Error as PlaywrightError
 from scrapling.parser import Selector
 from scrapling.engines._browsers._page import PageInfo, PagePool
 from scrapling.engines._browsers._validators import validate, PlaywrightConfig, StealthConfig
-from scrapling.engines._browsers._config_tools import __default_chrome_useragent__, __default_useragent__
+from scrapling.engines._browsers._config_tools import get_default_useragent
 from scrapling.engines.toolbelt.navigation import (
     construct_proxy_dict,
     create_intercept_handler,
@@ -446,9 +446,7 @@ class BaseSessionMixin:
         if config.useragent:
             self._context_options["user_agent"] = config.useragent
         elif not config.useragent and config.headless:
-            self._context_options["user_agent"] = (
-                __default_chrome_useragent__ if config.real_chrome else __default_useragent__
-            )
+            self._context_options["user_agent"] = get_default_useragent("chrome" if config.real_chrome else True)
 
         if not config.cdp_url:
             flags = self._browser_options["args"]

--- a/scrapling/engines/_browsers/_config_tools.py
+++ b/scrapling/engines/_browsers/_config_tools.py
@@ -1,4 +1,13 @@
+from functools import lru_cache
+
 from scrapling.engines.toolbelt.fingerprints import generate_headers
 
-__default_useragent__ = generate_headers(browser_mode=True).get("User-Agent")
-__default_chrome_useragent__ = generate_headers(browser_mode="chrome").get("User-Agent")
+
+@lru_cache(2, typed=True)
+def get_default_useragent(browser_mode: bool | str = True) -> str | None:
+    """Generate and cache the default user agent for a browser session.
+
+    :param browser_mode: The browser mode passed to the fingerprint generator.
+    :return: The generated user agent, if available.
+    """
+    return generate_headers(browser_mode=browser_mode).get("User-Agent")

--- a/tests/fetchers/test_browser_config.py
+++ b/tests/fetchers/test_browser_config.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+from unittest.mock import call, patch
+
+
+_CONFIG_MODULE = "scrapling.engines._browsers._config_tools"
+
+
+def test_config_tools_import_does_not_generate_headers() -> None:
+    """Importing browser configuration must not depend on header generation."""
+    sys.modules.pop(_CONFIG_MODULE, None)
+    try:
+        with patch(
+            "scrapling.engines.toolbelt.fingerprints.generate_headers",
+            side_effect=ValueError("No headers based on this input can be generated."),
+        ) as generate_headers:
+            importlib.import_module(_CONFIG_MODULE)
+
+        generate_headers.assert_not_called()
+    finally:
+        sys.modules.pop(_CONFIG_MODULE, None)
+
+
+def test_default_useragent_is_generated_on_demand() -> None:
+    """Default user agents should retain their modes and be cached after generation."""
+    config_tools = importlib.import_module(_CONFIG_MODULE)
+    config_tools.get_default_useragent.cache_clear()
+    try:
+        with patch.object(
+            config_tools,
+            "generate_headers",
+            side_effect=[{"User-Agent": "chromium"}, {"User-Agent": "chrome"}],
+        ) as generate_headers:
+            assert config_tools.get_default_useragent(True) == "chromium"
+            assert config_tools.get_default_useragent(True) == "chromium"
+            assert config_tools.get_default_useragent("chrome") == "chrome"
+
+        assert generate_headers.call_args_list == [
+            call(browser_mode=True),
+            call(browser_mode="chrome"),
+        ]
+    finally:
+        config_tools.get_default_useragent.cache_clear()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Scrapling!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue in the additional information section.
-->

Scrapling currently generates browser headers while importing `_config_tools`. If browserforge cannot produce headers for the detected browser version, that exception prevents unrelated entry points such as `scrapling mcp` from starting.

This change defers default user-agent generation until a headless browser session actually needs it and caches one value per browser mode. Explicit user agents and headed sessions keep their existing behavior. Regression tests verify that importing the configuration module does not call browserforge and that on-demand generation preserves the Chromium/Chrome modes and caching behavior.

Validation:
- `pytest -o addopts="" tests/fetchers/test_browser_config.py -q` (2 passed)
- Ruff check and format check for the three changed files
- mypy and pyright for the two changed source files
- Bandit and Vermin repository checks for the changed files
- real `scrapling mcp` stdio initialization returned a valid JSON-RPC result
- `git diff --check`

The exact browserforge exception was reproduced locally with Scrapling 0.4.12, browserforge 1.2.4, and MCP 1.29.0. A macOS runner was not available, so the platform-independent failure path is additionally covered with a deterministic mock.

### Type of change:
<!--
  What type of change does your PR introduce to Scrapling?
  NOTE: Please, check at least 1 box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes an issue: fixes #394
- This PR is related to an issue: #394
- Link to documentation pull request: **Not applicable**

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.
