### PR TITLE
fix(fingerprints): fallback gracefully when browserforge raises ValueError on unsupported Chrome versions

### DIFF
--- a/scrapling/engines/toolbelt/fingerprints.py
+++ b/scrapling/engines/toolbelt/fingerprints.py
@@ -53,7 +53,20 @@ def generate_headers(browser_mode: bool | str = False) -> Dict:
                 Browser(name="edge", min_version=140),
             ]
         )
-    return HeaderGenerator(browser=browsers, os=os_name, device="desktop").generate()
+    try:
+        return HeaderGenerator(browser=browsers, os=os_name, device="desktop").generate()
+    except ValueError:
+        # Fallback if the requested browser version constraint is not present in browserforge's dataset
+        fallback_browsers = [Browser(name="chrome")]
+        if not browser_mode:
+            fallback_browsers.extend(
+                [
+                    Browser(name="firefox"),
+                    Browser(name="edge"),
+                ]
+            )
+        return HeaderGenerator(browser=fallback_browsers, os=os_name, device="desktop").generate()
 
 
 __default_useragent__ = generate_headers(browser_mode=False).get("User-Agent")
+


### PR DESCRIPTION
### Description
When `chromium_version` or `chrome_version` hardcoded in `scrapling/engines/toolbelt/fingerprints.py` exceeds the maximum version supported in `browserforge`'s header dataset (`apify-fingerprint-datapoints`), `HeaderGenerator.generate()` raises a `ValueError`:

```text
ValueError: No headers based on this input can be generated. Please relax or change some of the requirements you specified.
```

Because `generate_headers(browser_mode=False)` is executed at module import time in `scrapling/engines/_browsers/_config_tools.py`, this `ValueError` crashes any application importing `scrapling` at boot time.

### Fix
- Wrapped `HeaderGenerator(...).generate()` in a `try...except ValueError` block in `generate_headers()`.
- If the exact `min_version=ver, max_version=ver` constraint is not present in `browserforge`'s dataset, it falls back to unconstrained browser definitions.
- Ensures `generate_headers()` always returns valid headers without crashing.