### PR TITLE
fix(fingerprints): fall back to a usable browser version instead of crashing at import

### DIFF
--- a/scrapling/engines/toolbelt/fingerprints.py
+++ b/scrapling/engines/toolbelt/fingerprints.py
@@ -5,8 +5,10 @@ Functions related to generating headers and fingerprints generally
 from functools import lru_cache
 from platform import system as platform_system
 
+from apify_fingerprint_datapoints import get_browser_helper_file
 from browserforge.headers import Browser, HeaderGenerator
 from browserforge.headers.generator import SUPPORTED_OPERATING_SYSTEMS
+from orjson import loads
 
 from scrapling.core._types import Dict, Literal, Tuple
 
@@ -34,6 +36,47 @@ def get_os_name() -> OSName | Tuple:
             return SUPPORTED_OPERATING_SYSTEMS
 
 
+@lru_cache(4, typed=True)
+def _dataset_versions(name: str) -> Tuple:
+    """Get the major versions of a browser that the installed fingerprints dataset ships with.
+
+    :param name: The browser name as browserforge knows it
+    :return: The versions found, ordered from the newest to the oldest
+    """
+    prefix = f"{name}/"
+    entries = loads(get_browser_helper_file().read_bytes())
+    versions = {int(entry[len(prefix) :].split(".")[0]) for entry in entries if entry.startswith(prefix)}
+    return tuple(sorted(versions, reverse=True))
+
+
+@lru_cache(8, typed=True)
+def _newest_supported_version(name: str, ceiling: int, os_name: OSName | Tuple) -> int:
+    """Find the newest version of a browser that the installed browserforge dataset can still generate headers for.
+
+    :param name: The browser name as browserforge knows it
+    :param ceiling: The wanted version, no version newer than it is considered
+    :param os_name: The same OS constraint the caller uses, as it affects which versions are usable
+    :return: The newest usable version, or `ceiling` itself if none was found
+    """
+    # Shipping a version doesn't mean headers can be generated for it, as the OS and the device
+    # have to line up with it as well, so each candidate is confirmed before we settle on it
+    for version in _dataset_versions(name):
+        if version > ceiling:
+            continue
+
+        try:
+            HeaderGenerator(
+                browser=[Browser(name=name, min_version=version, max_version=version)],
+                os=os_name,
+                device="desktop",
+            ).generate()
+            return version
+        except ValueError:
+            continue
+
+    return ceiling
+
+
 def generate_headers(browser_mode: bool | str = False) -> Dict:
     """Generate real browser-like headers using browserforge's generator
 
@@ -53,7 +96,15 @@ def generate_headers(browser_mode: bool | str = False) -> Dict:
                 Browser(name="edge", min_version=140),
             ]
         )
-    return HeaderGenerator(browser=browsers, os=os_name, device="desktop").generate()
+    try:
+        return HeaderGenerator(browser=browsers, os=os_name, device="desktop").generate()
+    except ValueError:
+        # The versions above are pinned to the browsers we drive, but browserforge's dataset is shipped
+        # separately and can lag behind them. Degrading to the newest version it does know about keeps the
+        # pinning intent while stopping that data gap from turning into an import-time crash.
+        supported = _newest_supported_version("chrome", ver, os_name)
+        browsers[0] = Browser(name="chrome", min_version=supported, max_version=supported)
+        return HeaderGenerator(browser=browsers, os=os_name, device="desktop").generate()
 
 
 __default_useragent__ = generate_headers(browser_mode=False).get("User-Agent")

--- a/tests/fetchers/test_utils.py
+++ b/tests/fetchers/test_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from scrapling.engines.toolbelt.convertor import ResponseFactory
@@ -8,6 +10,7 @@ from scrapling.engines.toolbelt.navigation import (
     create_async_intercept_handler,
     _is_domain_blocked,
 )
+from scrapling.engines.toolbelt import fingerprints
 from scrapling.engines.toolbelt.fingerprints import get_os_name, generate_headers
 
 
@@ -234,6 +237,42 @@ class TestFingerprintFunctions:
 
         assert isinstance(headers, dict)
         assert "User-Agent" in headers
+
+    def test_browser_default_useragents(self):
+        """Test that importing the browser fetchers works and exposes usable default user agents"""
+        from scrapling.engines._browsers._config_tools import (
+            __default_chrome_useragent__,
+            __default_useragent__,
+        )
+
+        for useragent in (__default_useragent__, __default_chrome_useragent__):
+            assert isinstance(useragent, str)
+            assert len(useragent) > 0
+
+    @pytest.mark.parametrize("browser_mode", [False, True, "chrome"])
+    def test_generate_headers_with_unsupported_version(self, browser_mode, monkeypatch):
+        """Test that headers are still generated when the pinned version is newer than browserforge's dataset"""
+        monkeypatch.setattr(fingerprints, "chromium_version", 999)
+        monkeypatch.setattr(fingerprints, "chrome_version", 999)
+
+        headers = generate_headers(browser_mode=browser_mode)
+
+        assert isinstance(headers, dict)
+        assert len(headers.get("User-Agent", "")) > 0
+
+    def test_generate_headers_keeps_supported_version(self, monkeypatch):
+        """Test that a version the dataset does support is used as-is without falling back"""
+        # Discover the newest supported version through the fallback itself, so nothing is hardcoded here
+        monkeypatch.setattr(fingerprints, "chrome_version", 999)
+        supported = int(re.search(r"Chrome/(\d+)", generate_headers(browser_mode="chrome")["User-Agent"]).group(1))
+
+        fallbacks = []
+        monkeypatch.setattr(fingerprints, "chrome_version", supported)
+        monkeypatch.setattr(fingerprints, "_newest_supported_version", lambda *args: fallbacks.append(args))
+        headers = generate_headers(browser_mode="chrome")
+
+        assert not fallbacks, "The fallback ran for a version browserforge already supports"
+        assert f"Chrome/{supported}." in headers["User-Agent"]
 
 
 class TestResponse:


### PR DESCRIPTION
Fixes #394, fixes #396.

## The problem

Every browser fetcher fails to import on a clean install:

```
$ pip install "scrapling[fetchers]"
$ python -c "from scrapling.fetchers import StealthyFetcher"
...
  File "scrapling/engines/_browsers/_config_tools.py", line 3, in <module>
    __default_useragent__ = generate_headers(browser_mode=True).get("User-Agent")
  File "scrapling/engines/toolbelt/fingerprints.py", line 56, in generate_headers
    return HeaderGenerator(browser=browsers, os=os_name, device="desktop").generate()
  File "browserforge/headers/generator.py", line 230, in _get_headers
    raise ValueError(
ValueError: No headers based on this input can be generated. Please relax or change some of the requirements you specified.
```

## Root cause

`generate_headers()` pins the version exactly:

```python
browsers = [Browser(name="chrome", min_version=ver, max_version=ver)]
```

with `ver = 149`, but the installed dataset stops earlier. Measured on `browserforge==1.2.4` /
`apify-fingerprint-datapoints==0.14.0`:

| browser | newest shipped |
|---|---|
| chrome | 143 |
| firefox | 144 |
| edge | 141 |

Since `generate_headers()` runs at module scope in both `fingerprints.py` and `_config_tools.py`,
this is an import-time crash rather than a degraded fingerprint. The call at `fingerprints.py:59`
survives because it also offers firefox/edge and browserforge treats the list as alternatives; the
two chrome-only calls in `_config_tools.py` are the ones that raise.

## Why not just lower the constant

Lowering `chrome_version` to 143 works today and breaks again on the next bump — that has happened at
every release since 0.4.2 (145 → 147 → 148 → 149). The constants are meant to track the browser
being driven, so they should be free to move ahead of the dataset. The data is also no longer
something a user can refresh: as of browserforge 1.2.4 it ships in the separate
`apify-fingerprint-datapoints` package and `python -m browserforge update` is a deprecated no-op. So
the version gap can only be closed by a release of that package, and Scrapling shouldn't be unusable
in the meantime.

This PR leaves the constants at 149 and makes the mismatch non-fatal instead.

## The fix

Keep the exact pin as the happy path, and add an `except ValueError` fallback that picks the newest
version the installed dataset can actually be used with:

- **Candidates come from the datapack**, so the search is bounded by real data rather than a guessed
  range.
- **Each candidate is confirmed through `HeaderGenerator` before it's used.** Being shipped isn't
  sufficient on its own — the OS has to line up too. This is the part that matters: **on Linux the
  newest shipped Chrome (143) still fails, and only 141 is usable.** Selecting the newest shipped
  version would leave #396 (the Linux report) unfixed.
- Both lookups are `lru_cache`d, so the probe runs at most once per (browser, ceiling, OS).

Worst case is 5 `generate()` calls; the happy path adds none.

## Before / after

Requesting the pinned 149:

| OS | before | after |
|---|---|---|
| macOS | `ValueError` | `Chrome/143` |
| Linux | `ValueError` | `Chrome/141` |
| Windows | `ValueError` | `Chrome/143` |

The happy path is unchanged — with a version the dataset supports, the UA reports exactly that
version and the fallback never executes (asserted in the tests):

| requested | result | fallback ran |
|---|---|---|
| 143 (macOS) | `Chrome/143` | no |
| 130 | `Chrome/130` | no |
| 999 | `Chrome/143` | yes |

## Tests

Added to `TestFingerprintFunctions` in `tests/fetchers/test_utils.py`:

1. the browser fetchers import and expose non-empty default user agents;
2. headers are still generated with the version monkeypatched to `999`, across all three
   `browser_mode` values;
3. a supported version is used *exactly*, with an assertion that the fallback did **not** run — so a
   future change can't silently downgrade a working case.

Test 3 discovers the supported version at runtime instead of hardcoding it, so it won't rot as the
datapack moves.

Full suite locally: **814 passed**, with 4 failures / 2 collection errors that are present on a clean
`dev` checkout too and unrelated to this change (all `mcp.server.fastmcp` under mcp 2.0.0, i.e. #392).
Before this change the same suite could not even collect: 40 collection errors and 411 passed.

## Relationship to the other open PRs

There are three open PRs for this bug, which I found only after writing this one — happy to close
this if you prefer one of them, but the platform differences are worth recording:

| | approach | macOS | Linux | Windows |
|---|---|---|---|---|
| #397 | drop the version pin on fallback | `Chrome/140` | `Chrome/141` | `Chrome/141` |
| #398 | use the newest version in the datapack | `Chrome/143` | **`ValueError`** | `Chrome/143` |
| this | newest datapack version *confirmed usable* | `Chrome/143` | `Chrome/141` | `Chrome/143` |

- **#398** has the right idea and this PR is essentially it plus one check. As written it still
  crashes on Linux, because it assumes a version present in the datapack can be generated for.
- **#397** does stop the crash everywhere, but dropping `min_version` lets browserforge sample the
  whole range — it returns `Chrome/140` on macOS where 143 is available, which weakens the pinning the
  comment above the constants describes as deliberate.
- **#395** is complementary rather than competing: it defers the module-scope calls to session
  startup. That's worth doing on its own merits — it's what turned this data gap into a total import
  failure for everyone, including users who only wanted the parser — but it relocates this particular
  error rather than removing it, since `generate_headers(browser_mode=True)` still raises when the
  session actually starts. #395 and this change fit together.
