### PR TITLE
fix(parser): find/find_all with class_ silently miss multi-class elements

### DIFF
--- a/scrapling/parser.py
+++ b/scrapling/parser.py
@@ -762,7 +762,11 @@ class Selector(SelectorsGeneration):
             for key, value in attributes.items():
                 value = value.replace('"', r"\"")  # Escape double quotes in user input
                 # Not escaping anything with the key so the user can pass patterns like {'href*': '/p/'} or get errors :)
-                selector += '[{}="{}"]'.format(key, value)
+                if key == "class":
+                    # `class` is a space-separated list, so exact-match [class="x"] misses class="x y"; match each name with ~=
+                    selector += "".join('[class~="{}"]'.format(t) for t in value.split())
+                else:
+                    selector += '[{}="{}"]'.format(key, value)
             if selector != "*":
                 selectors.append(selector)
 

--- a/tests/parser/test_general.py
+++ b/tests/parser/test_general.py
@@ -162,6 +162,20 @@ class TestSimilarElements:
         assert len(similar_high_rated_reviews) == 1
 
 
+class TestFindByClass:
+    def test_find_all_matches_multi_class_element(self, page):
+        """A single class token should match elements that carry other classes too"""
+        assert len(page.find_all("div", class_="stock")) == 3
+        assert len(page.find_all("div", class_="hidden")) == 3
+        assert page.find("div", class_="stock") is not None
+
+    def test_find_all_matches_all_of_multiple_tokens(self, page):
+        """Multiple class tokens all have to be present, regardless of order"""
+        assert len(page.find_all("div", class_="hidden stock")) == 3
+        assert len(page.find_all("div", class_="stock hidden")) == 3
+        assert page.find_all("div", class_="hidden nonexistent") == []
+
+
 # Error Handling Tests
 class TestErrorHandling:
     def test_invalid_selector_initialization(self):


### PR DESCRIPTION
Hey! If an element has more than one class, looking it up by one of them comes back empty. No error, just nothing:

```python
page = Selector(content='<div class="product featured">ONLY PRODUCT</div>')
page.css('.product')                    # finds it  ✓
page.find_all('div', class_='product')  # []  ← empty, even though it's right there
```

It looks for a class of exactly `"product"`, but classes are a list of words, so anything with a second class slips through. `css()` and `has_class` both find it, and the README shows them as the same thing.

Tiny fix so it matches `css()` and BeautifulSoup. Added tests in `TestFindByClass` that fail on `dev` today, rest still pass.

Written by me, reviewed by Claude Code.
