### PR TITLE
fix: stop retrying libcurl errors that a retry cannot change

### DIFF
--- a/scrapling/engines/static.py
+++ b/scrapling/engines/static.py
@@ -4,7 +4,7 @@ from time import sleep as time_sleep
 from asyncio import sleep as asyncio_sleep
 
 from curl_cffi.curl import CurlError
-from curl_cffi import CurlHttpVersion
+from curl_cffi import CurlECode, CurlHttpVersion
 from curl_cffi.requests import (
     BrowserTypeLiteral,
     Session as CurlSession,
@@ -31,6 +31,47 @@ from ._browsers._types import RequestsSession, GetRequestParams, DataRequestPara
 from .toolbelt.fingerprints import generate_headers, __default_useragent__
 
 _NO_SESSION: Any = object()
+
+# libcurl codes that describe the client's own configuration or the URL it was
+# given. Sending the identical request again cannot turn any of them into a
+# success, so a retry only adds `retry_delay` to the time before the caller
+# learns what went wrong.
+_FATAL_CURL_CODES = frozenset(
+    {
+        CurlECode.UNSUPPORTED_PROTOCOL,
+        CurlECode.URL_MALFORMAT,
+        CurlECode.BAD_FUNCTION_ARGUMENT,
+        CurlECode.SSL_ENGINE_NOTFOUND,
+        CurlECode.SSL_ENGINE_SETFAILED,
+        CurlECode.SSL_CERTPROBLEM,
+        CurlECode.SSL_CIPHER,
+        CurlECode.SSL_CACERT_BADFILE,
+    }
+)
+
+# Verification failures for the certificate the peer presented. Deterministic
+# for that peer, but a rotator hands out a different exit on the next attempt,
+# and a TLS-intercepting middlebox on one route is a real cause of these - so
+# they are only worth failing fast on when the request would be identical.
+_PEER_CERTIFICATE_CURL_CODES = frozenset(
+    {
+        CurlECode.PEER_FAILED_VERIFICATION,
+        CurlECode.SSL_ISSUER_ERROR,
+    }
+)
+
+
+def _is_retryable(error: CurlError, rotating: bool) -> bool:
+    """Whether sending the same request again could plausibly return something else.
+
+    `rotating` says whether a proxy rotator will pick a different exit for the
+    next attempt, which is what decides the peer-certificate cases.
+    """
+    if error.code in _FATAL_CURL_CODES:
+        return False
+    if error.code in _PEER_CERTIFICATE_CURL_CODES:
+        return rotating
+    return True
 
 
 def _select_random_browser(impersonate: ImpersonateType) -> Optional[BrowserTypeLiteral]:
@@ -244,6 +285,8 @@ class _SyncSessionLogic(_ConfigurationLogic):
         if not session:
             raise RuntimeError("No active session available.")  # pragma: no cover
 
+        rotating = self._proxy_rotator is not None and static_proxy is None
+
         try:
             for attempt in range(max_retries):
                 proxy: Optional[ProxyType]
@@ -259,6 +302,9 @@ class _SyncSessionLogic(_ConfigurationLogic):
                     result = ResponseFactory.from_http_request(response, selector_config, meta={"proxy": proxy})
                     return result
                 except CurlError as e:  # pragma: no cover
+                    if not _is_retryable(e, rotating):
+                        log.error(f"Request failed with an error that a retry cannot change: {e}")
+                        raise
                     if attempt < max_retries - 1:
                         # Now if the rotator is enabled, we will try again with the new proxy
                         # If it's not enabled, then we will try again with the same proxy
@@ -462,6 +508,8 @@ class _ASyncSessionLogic(_ConfigurationLogic):
         if not session:
             raise RuntimeError("No active session available.")  # pragma: no cover
 
+        rotating = self._proxy_rotator is not None and static_proxy is None
+
         try:
             # Determine if we should use proxy rotation
             for attempt in range(max_retries):
@@ -477,6 +525,9 @@ class _ASyncSessionLogic(_ConfigurationLogic):
                     result = ResponseFactory.from_http_request(response, selector_config, meta={"proxy": proxy})
                     return result
                 except CurlError as e:  # pragma: no cover
+                    if not _is_retryable(e, rotating):
+                        log.error(f"Request failed with an error that a retry cannot change: {e}")
+                        raise
                     if attempt < max_retries - 1:
                         # Now if the rotator is enabled, we will try again with the new proxy
                         # If it's not enabled, then we will try again with the same proxy

--- a/tests/fetchers/async/test_requests_session.py
+++ b/tests/fetchers/async/test_requests_session.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
+from curl_cffi import CurlECode
 from curl_cffi.curl import CurlError
 
 from scrapling.engines.static import _ASyncSessionLogic as AsyncFetcherSession, AsyncFetcherClient
@@ -85,3 +86,69 @@ class TestFetcherSession:
                 await session.get("http://example.com", retries=0)
 
             assert mocked_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_certificate_failure_is_not_retried(self):
+        """Repeating the identical request cannot change the certificate verification result (#426)"""
+        async with AsyncFetcherSession(retries=3, retry_delay=0) as session:
+            with (
+                patch.object(session._async_curl_session, "request", new=AsyncMock()) as mocked_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()),
+            ):
+                mocked_request.side_effect = CurlError(
+                    "SSL peer certificate was not OK", CurlECode.PEER_FAILED_VERIFICATION
+                )
+                with pytest.raises(CurlError):
+                    await session.get("https://expired.badssl.com/")
+
+            assert mocked_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_certificate_failure_is_retried_while_rotating(self):
+        """A rotator makes the next attempt a different exit, so a route-caused certificate failure is worth retrying"""
+        rotator = ProxyRotator(["http://p1:8080", "http://p2:8080"])
+
+        async with AsyncFetcherSession(proxy_rotator=rotator, retries=2, retry_delay=0) as session:
+            with (
+                patch.object(session._async_curl_session, "request", new=AsyncMock()) as mocked_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()),
+            ):
+                mocked_request.side_effect = [
+                    CurlError("SSL peer certificate was not OK", CurlECode.PEER_FAILED_VERIFICATION),
+                    MagicMock(),
+                ]
+                await session.get("https://example.com")
+
+            assert mocked_request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_client_side_error_is_not_retried_even_while_rotating(self):
+        """A malformed URL holds on every exit, so rotation does not make it worth repeating"""
+        rotator = ProxyRotator(["http://p1:8080", "http://p2:8080"])
+
+        async with AsyncFetcherSession(proxy_rotator=rotator, retries=3, retry_delay=0) as session:
+            with (
+                patch.object(session._async_curl_session, "request", new=AsyncMock()) as mocked_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()),
+            ):
+                mocked_request.side_effect = CurlError("URL using bad/illegal format", CurlECode.URL_MALFORMAT)
+                with pytest.raises(CurlError):
+                    await session.get("http://example.com")
+
+            assert mocked_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_transient_error_is_still_retried(self):
+        """Errors that are not classified as deterministic must keep their existing retry behaviour"""
+        async with AsyncFetcherSession(retries=3, retry_delay=0) as session:
+            with (
+                patch.object(session._async_curl_session, "request", new=AsyncMock()) as mocked_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()),
+            ):
+                mocked_request.side_effect = [
+                    CurlError("Connection timed out", CurlECode.OPERATION_TIMEDOUT),
+                    MagicMock(),
+                ]
+                await session.get("http://example.com")
+
+            assert mocked_request.call_count == 2

--- a/tests/fetchers/sync/test_requests_session.py
+++ b/tests/fetchers/sync/test_requests_session.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock
+from curl_cffi import CurlECode
 from curl_cffi.curl import CurlError
 
 from scrapling.engines.static import _SyncSessionLogic as FetcherSession, FetcherClient
@@ -105,3 +106,65 @@ class TestFetcherSession:
                 session.get("http://example.com", retries=0)
 
             assert mocked_request.call_count == 1
+
+    def test_certificate_failure_is_not_retried(self):
+        """Repeating the identical request cannot change the certificate verification result (#426)"""
+        with FetcherSession(retries=3, retry_delay=0) as session:
+            with (
+                patch.object(session._curl_session, "request") as mocked_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()),
+            ):
+                mocked_request.side_effect = CurlError(
+                    "SSL peer certificate was not OK", CurlECode.PEER_FAILED_VERIFICATION
+                )
+                with pytest.raises(CurlError):
+                    session.get("https://expired.badssl.com/")
+
+            assert mocked_request.call_count == 1
+
+    def test_certificate_failure_is_retried_while_rotating(self):
+        """A rotator makes the next attempt a different exit, so a route-caused certificate failure is worth retrying"""
+        rotator = ProxyRotator(["http://p1:8080", "http://p2:8080"])
+
+        with FetcherSession(proxy_rotator=rotator, retries=2, retry_delay=0) as session:
+            with (
+                patch.object(session._curl_session, "request") as mocked_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()),
+            ):
+                mocked_request.side_effect = [
+                    CurlError("SSL peer certificate was not OK", CurlECode.PEER_FAILED_VERIFICATION),
+                    MagicMock(),
+                ]
+                session.get("https://example.com")
+
+            assert mocked_request.call_count == 2
+
+    def test_client_side_error_is_not_retried_even_while_rotating(self):
+        """A malformed URL holds on every exit, so rotation does not make it worth repeating"""
+        rotator = ProxyRotator(["http://p1:8080", "http://p2:8080"])
+
+        with FetcherSession(proxy_rotator=rotator, retries=3, retry_delay=0) as session:
+            with (
+                patch.object(session._curl_session, "request") as mocked_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()),
+            ):
+                mocked_request.side_effect = CurlError("URL using bad/illegal format", CurlECode.URL_MALFORMAT)
+                with pytest.raises(CurlError):
+                    session.get("http://example.com")
+
+            assert mocked_request.call_count == 1
+
+    def test_transient_error_is_still_retried(self):
+        """Errors that are not classified as deterministic must keep their existing retry behaviour"""
+        with FetcherSession(retries=3, retry_delay=0) as session:
+            with (
+                patch.object(session._curl_session, "request") as mocked_request,
+                patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()),
+            ):
+                mocked_request.side_effect = [
+                    CurlError("Connection timed out", CurlECode.OPERATION_TIMEDOUT),
+                    MagicMock(),
+                ]
+                session.get("http://example.com")
+
+            assert mocked_request.call_count == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Scrapling!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue in the additional information section.
-->

`_make_request` catches every `CurlError` and retries it. Some of those errors describe the client's own configuration, or the URL it was handed, and repeating the identical request cannot turn them into a success - it only adds `retry_delay` to the time before the caller learns what went wrong. #426 reports this for an expired certificate.

This adds a classification step in front of the existing retry, in both the sync and the async loop. It does not change the retry machinery itself.

**The classification is deliberately not a flat blacklist, because one group of codes depends on the rotator:**

- `_FATAL_CURL_CODES` - the request is wrong regardless of the route: `UNSUPPORTED_PROTOCOL` (1), `URL_MALFORMAT` (3), `BAD_FUNCTION_ARGUMENT` (43), `SSL_ENGINE_NOTFOUND` (53), `SSL_ENGINE_SETFAILED` (54), `SSL_CERTPROBLEM` (58), `SSL_CIPHER` (59), `SSL_CACERT_BADFILE` (77). The three SSL codes in that list are about the local client's own certificate, key, CA file or cipher list, not about anything the peer sent. Never retried.
- `_PEER_CERTIFICATE_CURL_CODES` - `PEER_FAILED_VERIFICATION` (60) and `SSL_ISSUER_ERROR` (83). These are deterministic for a given peer, which is #426's case, but the loop already calls `self._proxy_rotator.get_proxy()` at the top of every attempt, so with a rotator the next attempt is a different exit. A TLS-intercepting middlebox on one exit is a real cause of a code 60 that the next exit does not reproduce. So these fail fast only when the next attempt would be identical - no rotator, or a per-request `proxy=` that has pinned the route.

Everything else keeps its current behaviour. `OPERATION_TIMEDOUT` and `COULDNT_RESOLVE_HOST` are still retried; the second one showed up on its own during the runs below, on a DNS blip, and was correctly retried away.

Two smaller decisions worth stating, since both could reasonably have gone the other way:

- Matching is on `CurlError.code`, not on the message text. The codes are stable across libcurl versions and the wording is not.
- I did not extend the existing `is_proxy_error` for this. That helper matches lowercase substrings because it also has to classify Playwright errors, which carry no libcurl code; here the code is available and is the better key. The two are used for different things - `is_proxy_error` only picks the wording of a log line.

### Measurements

The reporter's own command, on this machine, Windows 10, Python 3.11.0, curl_cffi 0.16.2, no proxy, against `dev` at `458e2a2`.

Before:

```
$ scrapling extract get "https://expired.badssl.com/" /tmp/tls.md
WARNING: Attempt 1 failed: ... curl: (60) ... certificate has expired ... Retrying in 1 seconds...
WARNING: Attempt 2 failed: ... curl: (60) ... certificate has expired ... Retrying in 1 seconds...
ERROR: Failed after 3 attempts: ... curl: (60) ... certificate has expired ...
```

After:

```
$ scrapling extract get "https://expired.badssl.com/" /tmp/tls.md
ERROR: Request failed with an error that a retry cannot change: ... curl: (60) ... certificate has expired ...
```

Exit code is 1 either way and the same `CertificateVerifyError` reaches the caller; only the two pointless attempts and the two `retry_delay` sleeps are gone. Through the library rather than the CLI, with `FetcherSession(retries=3, retry_delay=1)`, counting the retry log lines: 3 attempts in 2.98 s and 3.72 s before, 1 attempt in 0.42 s and 1.09 s after, two runs a side.

### What I ran

- `pytest tests/fetchers` - **38 failed, 197 passed** with the patch and **38 failed, 189 passed** without it. The `FAILED` lists are identical, so the 8 new tests are the whole difference. Those 38 are this machine's missing extras: `markdownify` from `[rag]`, and the Playwright browser binaries. I skipped `test_pages.py`, `test_cloudflare_solver.py` and `test_page_reuse.py` for the same reason, so **I have not reproduced a fully green suite locally** and CI is the real check.
- `ruff check` and `ruff format --diff` at the pinned 0.14.5 - clean.
- `bandit -r -c .bandit.yml` - 0 issues.
- `vermin -t=3.10- --violations --eval-annotations` - passes.
- `mypy scrapling/` - `Success: no issues found in 58 source files`.
- `pyright scrapling/` - 12 errors, none in a file this PR touches, all of them imports of optional extras that CI installs with `.[all]` and I did not.

### Type of change:
<!--
  What type of change does your PR introduce to Scrapling?
  NOTE: Please, check at least 1 box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes an issue: fixes #426
- This PR is related to an issue: #
- Link to documentation pull request: **

### AI assistance disclosure

Per [AI_POLICY.md](https://github.com/D4Vinci/Scrapling/blob/main/AI_POLICY.md): this PR was written with Claude Code. It wrote the patch, the tests and this description. I directed the work, chose the rotator-dependent split over a flat blacklist after reading the loop, and ran every command quoted above myself on my own machine. I understand the change and can defend any line of it. If I answer a review comment with AI help I will say so in that comment.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.
