### PR TITLE
fix: reject non-2xx CLI responses

### DIFF
--- a/scrapling/cli.py
+++ b/scrapling/cli.py
@@ -12,7 +12,7 @@ from scrapling.core._types import List, Optional, Dict, Tuple, Any, Callable
 from orjson import loads as json_loads, JSONDecodeError
 
 try:
-    from click import command, option, Choice, group, argument, version_option, UsageError
+    from click import command, option, Choice, group, argument, version_option, UsageError, ClickException
 except (ImportError, ModuleNotFoundError) as e:
     raise ModuleNotFoundError(
         "You need to install scrapling with any of the extras to enable Shell commands. See: https://scrapling.readthedocs.io/en/latest/#installation"
@@ -58,6 +58,8 @@ def __Request_and_Save(
     if ai_targeted:
         kwargs.setdefault("block_ads", True)
     response = fetcher_func(url, **kwargs)
+    if not 200 <= response.status < 300:
+        raise ClickException(f"Request failed with status {response.status}")
     Convertor.write_content_to_file(response, str(output_path), css_selector, main_content_only=ai_targeted)
     log.info(f"Content successfully saved to '{output_path}'")
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -12,6 +12,7 @@ from scrapling.cli import main, shell, mcp, get, post, put, delete, fetch, steal
 def configure_selector_mock():
     """Helper function to create a properly configured Selector mock"""
     mock_response = MagicMock(spec=Selector)
+    mock_response.status = 200
     mock_response.body = "<html><body>Test content</body></html>"
     mock_response.html_content = "<html><body>Test content</body></html>"
     mock_response.encoding = "utf-8"
@@ -177,6 +178,22 @@ class TestCLI:
                 ],
             )
             assert result.exit_code == 0
+
+    def test_extract_get_rejects_non_success_response(self, runner, tmp_path, html_url):
+        """A failed HTTP response is not saved as successful output"""
+        output_file = tmp_path / "output.md"
+
+        with patch("scrapling.fetchers.Fetcher.get") as mock_get:
+            mock_response = configure_selector_mock()
+            mock_response.status = 403
+            mock_get.return_value = mock_response
+
+            result = runner.invoke(get, [html_url, str(output_file)])
+
+        assert result.exit_code == 1
+        assert "Error: Request failed with status 403" in result.output
+        assert "Content successfully saved" not in result.output
+        assert not output_file.exists()
 
     def test_extract_post_command(self, runner, tmp_path, html_url):
         """Test extract `post` command"""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Scrapling!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue in the additional information section.
-->

The CLI currently writes every fetched response to the requested output path and reports success, even when the HTTP status is not successful. This change rejects statuses outside 200–299 before conversion or file writing, so failed responses exit 1 without creating a successful-looking artifact.

The check lives in the shared CLI save path, so it covers HTTP and browser extract commands without changing fetcher, retry, redirect, or library response behavior. The regression test covers the reported 403 case, including the exit code, error text, success message, and output file.

Tests:
- `.venv\Scripts\python.exe -m pytest tests\cli\test_cli.py -q` — 23 passed
- `.venv\Scripts\ruff.exe check scrapling\ tests\cli\test_cli.py` — passed
- `.venv\Scripts\ruff.exe format --check scrapling\cli.py tests\cli\test_cli.py` — passed
- `.venv\Scripts\bandit.exe -r -c .bandit.yml scrapling\` — 0 issues
- `.venv\Scripts\mypy.exe scrapling\` — no issues in 58 source files
- `.venv\Scripts\pyright.exe --pythonpath .venv\Scripts\python.exe scrapling\` — 0 errors, 0 warnings

A broader Windows run completed with 925 passed and 36 unrelated failures. The failures were outside the CLI suite and were primarily browser-backed tests without installed Playwright/Patchright binaries, plus existing Windows path/file-lock assumptions. The macOS Python 3.10–3.13 tox matrix remains CI-only here.

### Type of change:
<!--
  What type of change does your PR introduce to Scrapling?
  NOTE: Please, check at least 1 box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes an issue: fixes #425
- This PR is related to an issue: #
- Link to documentation pull request: **

### AI assistance disclosure

This PR was developed with Codex assistance for investigation, implementation, tests, validation, and drafting. I reviewed the two-file diff, reproduced the original 403 behavior, ran the checks listed above, and understand the change: the CLI now stops before conversion or file writing whenever the response status is outside 200–299.

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.

