### PR TITLE
fix(fetchers): fail fast on deterministic TLS certificate errors

### DIFF
--- a/scrapling/engines/static.py
+++ b/scrapling/engines/static.py
@@ -26,7 +26,7 @@ from scrapling.core._types import (
 
 from .toolbelt.custom import Response
 from .toolbelt.convertor import ResponseFactory
-from .toolbelt.proxy_rotation import ProxyRotator, is_proxy_error
+from .toolbelt.proxy_rotation import ProxyRotator, is_proxy_error, is_ssl_verification_error
 from ._browsers._types import RequestsSession, GetRequestParams, DataRequestParams, ImpersonateType
 from .toolbelt.fingerprints import generate_headers, __default_useragent__
 
@@ -258,10 +258,13 @@ class _SyncSessionLogic(_ConfigurationLogic):
                     assert response is not None
                     result = ResponseFactory.from_http_request(response, selector_config, meta={"proxy": proxy})
                     return result
-                except CurlError as e:  # pragma: no cover
+                except CurlError as e:
                     if attempt < max_retries - 1:
-                        # Now if the rotator is enabled, we will try again with the new proxy
-                        # If it's not enabled, then we will try again with the same proxy
+                        # TLS certificate failures are deterministic: the same cert
+                        # will produce the same error on every attempt. Fail fast.
+                        if is_ssl_verification_error(e):
+                            log.error(f"TLS certificate verification failed (not retrying): {e}")
+                            raise
                         if is_proxy_error(e):
                             log.warning(
                                 f"Proxy '{proxy}' failed (attempt {attempt + 1}) | Retrying in {retry_delay} seconds..."
@@ -476,10 +479,13 @@ class _ASyncSessionLogic(_ConfigurationLogic):
                     response = await session.request(method, **request_args)
                     result = ResponseFactory.from_http_request(response, selector_config, meta={"proxy": proxy})
                     return result
-                except CurlError as e:  # pragma: no cover
+                except CurlError as e:
                     if attempt < max_retries - 1:
-                        # Now if the rotator is enabled, we will try again with the new proxy
-                        # If it's not enabled, then we will try again with the same proxy
+                        # TLS certificate failures are deterministic: the same cert
+                        # will produce the same error on every attempt. Fail fast.
+                        if is_ssl_verification_error(e):
+                            log.error(f"TLS certificate verification failed (not retrying): {e}")
+                            raise
                         if is_proxy_error(e):
                             log.warning(
                                 f"Proxy '{proxy}' failed (attempt {attempt + 1}) | Retrying in {retry_delay} seconds..."

--- a/scrapling/engines/toolbelt/__init__.py
+++ b/scrapling/engines/toolbelt/__init__.py
@@ -1,3 +1,3 @@
-from .proxy_rotation import ProxyRotator, is_proxy_error, cyclic_rotation
+from .proxy_rotation import ProxyRotator, is_proxy_error, cyclic_rotation, is_ssl_verification_error
 
-__all__ = ["ProxyRotator", "is_proxy_error", "cyclic_rotation"]
+__all__ = ["ProxyRotator", "is_proxy_error", "cyclic_rotation", "is_ssl_verification_error"]

--- a/scrapling/engines/toolbelt/proxy_rotation.py
+++ b/scrapling/engines/toolbelt/proxy_rotation.py
@@ -14,6 +14,28 @@ _PROXY_ERROR_INDICATORS = {
     "could not resolve proxy",
 }
 
+# curl_cffi TLS certificate verification error codes.
+# CURLE_SSL_PEER_CERTIFICATE / CURLE_PEER_FAILED_VERIFICATION = 60
+# These are deterministic: retrying the same request with the same cert
+# will always produce the same result. Fail fast.
+_SSL_CERT_ERROR_INDICATORS = {
+    "curl: (60)",  # expired / invalid / untrusted certificate
+    "certificate has expired",
+    "certificate verify failed",
+    "ssl: certificate_verify_failed",
+    "peer certificate cannot be authenticated",
+}
+
+
+def is_ssl_verification_error(error: Exception) -> bool:
+    """Return True when the error is a deterministic TLS certificate failure.
+
+    These cannot be resolved by retrying, so the caller should raise
+    immediately rather than sleeping and trying again.
+    """
+    error_msg = str(error).lower()
+    return any(indicator in error_msg for indicator in _SSL_CERT_ERROR_INDICATORS)
+
 
 def _get_proxy_key(proxy: ProxyType) -> str:
     """Generate a unique key for a proxy (for dicts it's server plus username)."""

--- a/tests/fetchers/async/test_requests_session.py
+++ b/tests/fetchers/async/test_requests_session.py
@@ -85,3 +85,30 @@ class TestFetcherSession:
                 await session.get("http://example.com", retries=0)
 
             assert mocked_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_ssl_cert_failure_does_not_retry(self):
+        """A TLS certificate verification error must fail immediately without retrying."""
+        ssl_error = CurlError("curl: (60) SSL certificate problem: certificate has expired")
+
+        async with AsyncFetcherSession(retries=3, retry_delay=0) as session:
+            with patch.object(session._async_curl_session, "request", new=AsyncMock(side_effect=ssl_error)) as mock_req:
+                with pytest.raises(CurlError, match="certificate has expired"):
+                    await session.get("https://expired.badssl.com/")
+
+            # Must have been called exactly ONCE — no retries
+            assert mock_req.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_transient_network_error_still_retries(self):
+        """Non-TLS errors (e.g., connection refused) still benefit from retry."""
+        transient_error = CurlError("curl: (7) Failed to connect to host")
+
+        async with AsyncFetcherSession(retries=3, retry_delay=0) as session:
+            with patch.object(
+                session._async_curl_session, "request", new=AsyncMock(side_effect=[transient_error, MagicMock()])
+            ) as mock_req:
+                with patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()):
+                    await session.get("https://example.com/")
+
+            assert mock_req.call_count == 2  # First failed, second succeeded

--- a/tests/fetchers/sync/test_requests_session.py
+++ b/tests/fetchers/sync/test_requests_session.py
@@ -105,3 +105,26 @@ class TestFetcherSession:
                 session.get("http://example.com", retries=0)
 
             assert mocked_request.call_count == 1
+
+    def test_ssl_cert_failure_does_not_retry(self):
+        """A TLS certificate verification error must fail immediately without retrying."""
+        ssl_error = CurlError("curl: (60) SSL certificate problem: certificate has expired")
+
+        with FetcherSession(retries=3, retry_delay=0) as session:
+            with patch.object(session._curl_session, "request", side_effect=ssl_error) as mock_req:
+                with pytest.raises(CurlError, match="certificate has expired"):
+                    session.get("https://expired.badssl.com/")
+
+            # Must have been called exactly ONCE — no retries
+            assert mock_req.call_count == 1
+
+    def test_transient_network_error_still_retries(self):
+        """Non-TLS errors (e.g., connection refused) still benefit from retry."""
+        transient_error = CurlError("curl: (7) Failed to connect to host")
+
+        with FetcherSession(retries=3, retry_delay=0) as session:
+            with patch.object(session._curl_session, "request", side_effect=[transient_error, MagicMock()]) as mock_req:
+                with patch("scrapling.engines.static.ResponseFactory.from_http_request", return_value=MagicMock()):
+                    session.get("https://example.com/")
+
+            assert mock_req.call_count == 2  # First failed, second succeeded

--- a/tests/fetchers/test_ssl_cert_error.py
+++ b/tests/fetchers/test_ssl_cert_error.py
@@ -1,0 +1,27 @@
+import pytest
+from scrapling.engines.toolbelt.proxy_rotation import is_ssl_verification_error
+from curl_cffi.curl import CurlError
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "curl: (60) SSL certificate problem: certificate has expired",
+        "curl: (60) SSL certificate problem: certificate verify failed",
+        "curl: (60) peer certificate cannot be authenticated with given CA certificates",
+    ],
+)
+def test_is_ssl_verification_error_true(msg):
+    assert is_ssl_verification_error(CurlError(msg)) is True
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "curl: (7) Failed to connect",
+        "curl: (28) Connection timed out",
+        "connection refused",
+    ],
+)
+def test_is_ssl_verification_error_false(msg):
+    assert is_ssl_verification_error(CurlError(msg)) is False


### PR DESCRIPTION
Resolves #426. Adds an \is_ssl_verification_error\ check to prevent the static and async fetchers from repeatedly retrying when hitting deterministic TLS issues like expired certificates (curl error code 60). Includes tests verifying that SSL errors raise immediately while transient errors still retry.