### PR TITLE
fix: keep robots.txt policies separate for HTTP and HTTPS

### DIFF
--- a/docs/spiders/getting-started.md
+++ b/docs/spiders/getting-started.md
@@ -174,11 +174,11 @@ class PoliteSpider(Spider):
 
 When enabled, the spider will:
 
-1. **Pre-fetch robots.txt** for all domains in `start_urls` before the crawl begins (concurrently).
-2. **Check every request** against the domain's robots.txt `Disallow` rules. Disallowed requests are silently dropped and counted in `stats.robots_disallowed_count`.
+1. **Pre-fetch robots.txt** for all origins in `start_urls` before the crawl begins (concurrently).
+2. **Check every request** against the origin's robots.txt `Disallow` rules. Disallowed requests are silently dropped and counted in `stats.robots_disallowed_count`.
 3. **Respect `Crawl-delay` and `Request-rate` directives** by taking the maximum of the directive and your configured `download_delay`. This means robots.txt delays never reduce your configured delay, only increase it when needed.
 
-Robots.txt files are fetched using the spider's default session and cached per domain for the entire crawl. Domains discovered mid-crawl (not in `start_urls`) have their robots.txt fetched on the first request to that domain.
+Robots.txt files are fetched using the spider's default session and cached per origin (scheme, hostname, and port) for the entire crawl. HTTP and HTTPS URLs on the same hostname have separate rules and delays. Origins discovered mid-crawl (not in `start_urls`) have their robots.txt fetched on the first request to that origin.
 
 **Note:** `robots_txt_obey` is turned off by default to avoid surprising behavior. If you enable it, it does not affect your concurrency settings (`concurrent_requests`, `concurrent_requests_per_domain`) -- only the delay between requests is adjusted.
 

--- a/scrapling/spiders/engine.py
+++ b/scrapling/spiders/engine.py
@@ -104,22 +104,23 @@ class CrawlerEngine:
         return False
 
     async def _get_domain_delay(self, request: Request) -> float:
-        """Resolve the effective download delay for a domain.
+        """Resolve the effective download delay for an origin.
 
         Takes the max of the spider's configured delay and any robots.txt
-        directives (Crawl-delay / Request-rate). Result is cached per domain.
+        directives (Crawl-delay / Request-rate). Result is cached per origin.
         """
         robots_manager = self._robots_manager
         if robots_manager is None:
             return self.spider.download_delay
 
-        domain = request.domain
+        parsed = urlparse(request.url)
+        origin = f"{parsed.scheme or 'https'}://{parsed.netloc}"
 
-        if domain in self._domain_delays:
-            return self._domain_delays[domain]
+        if origin in self._domain_delays:
+            return self._domain_delays[origin]
 
-        # For domains covered by _prefetch_robots_txt this is a local parser read.
-        # Domains discovered mid-crawl (not in start_urls) will fetch here.
+        # For origins covered by _prefetch_robots_txt this is a local parser read.
+        # Origins discovered mid-crawl (not in start_urls) will fetch here.
         c_delay, r_rate = await robots_manager.get_delay_directives(request.url, request.sid)
 
         delay = self.spider.download_delay
@@ -132,7 +133,7 @@ class CrawlerEngine:
         if c_delay is not None:
             delay = max(delay, c_delay)
 
-        self._domain_delays[domain] = delay
+        self._domain_delays[origin] = delay
         return delay
 
     def _rate_limiter(self, domain: str) -> CapacityLimiter:
@@ -334,19 +335,20 @@ class CrawlerEngine:
     async def _prefetch_robots_txt(self) -> None:
         """Pre-warm the robots.txt cache before the crawl loop starts.
 
-        Extracts unique domains from start_urls, preserving the original scheme.
+        Extracts unique origins from start_urls, preserving the original scheme.
         """
         if not self._robots_manager or not self.spider.start_urls:
             return
 
-        # Deduplicate by netloc, preserving the scheme from the first URL per domain
+        # Different schemes on the same authority can serve different robots.txt policies.
         seen: set[str] = set()
         seed_urls: list[str] = []
         for url in self.spider.start_urls:
             parsed = urlparse(url)
-            if parsed.netloc not in seen:
-                seen.add(parsed.netloc)
-                seed_urls.append(f"{parsed.scheme}://{parsed.netloc}/")
+            origin = f"{parsed.scheme or 'https'}://{parsed.netloc}"
+            if origin not in seen:
+                seen.add(origin)
+                seed_urls.append(f"{origin}/")
 
         await self._robots_manager.prefetch(seed_urls, self.session_manager.default_session_id)
 

--- a/scrapling/spiders/robotstxt.py
+++ b/scrapling/spiders/robotstxt.py
@@ -17,12 +17,12 @@ class RobotsTxtManager:
     async def _get_parser(self, url: str, sid: str) -> Protego:
         parsed = urlparse(url)
         domain = parsed.netloc
-
-        if domain in self._cache:
-            return self._cache[domain]
-
         scheme = parsed.scheme or "https"
         robots_url = f"{scheme}://{domain}/robots.txt"
+
+        if robots_url in self._cache:
+            return self._cache[robots_url]
+
         content = ""
         try:
             response = await self._fetch_fn(robots_url, sid)
@@ -37,11 +37,11 @@ class RobotsTxtManager:
             log.warning(f"Failed to parse robots.txt for {domain}: {e}")
             parser = Protego.parse("")
 
-        self._cache[domain] = parser
+        self._cache[robots_url] = parser
         return parser
 
     async def can_fetch(self, url: str, sid: str) -> bool:
-        """Check if a URL can be fetched according to the domain's robots.txt.
+        """Check if a URL can be fetched according to the origin's robots.txt.
 
         :param url: The full URL to check
         :param sid: Session ID for fetching robots.txt if not yet cached
@@ -52,7 +52,7 @@ class RobotsTxtManager:
     async def get_delay_directives(self, url: str, sid: str) -> tuple[Optional[float], Optional[tuple[int, int]]]:
         """Return both crawl-delay and request-rate in a single parser lookup.
 
-        :param url: Any URL on the domain to check
+        :param url: Any URL on the origin to check
         :param sid: Session ID for fetching robots.txt if not yet cached
         """
         parser = await self._get_parser(url, sid)
@@ -66,12 +66,12 @@ class RobotsTxtManager:
     async def prefetch(self, urls: list[str], sid: str) -> None:
         """Pre-warm the robots.txt cache for a list of seed URLs concurrently.
 
-        :param urls: Seed URLs whose domains should be pre-fetched (one per domain).
+        :param urls: Seed URLs whose origins should be pre-fetched (one per origin).
         :param sid: Session ID to use for the robots.txt fetch requests.
         """
         if not urls:
             return
-        log.debug(f"Pre-fetching robots.txt for {len(urls)} domain(s)")
+        log.debug(f"Pre-fetching robots.txt for {len(urls)} origin(s)")
         async with create_task_group() as tg:
             for url in urls:
                 tg.start_soon(self._get_parser, url, sid)

--- a/tests/spiders/test_engine.py
+++ b/tests/spiders/test_engine.py
@@ -940,6 +940,29 @@ class TestPauseDuringCrawl:
 class TestPrefetchRobotsTxt:
     """_prefetch_robots_txt warms the robots.txt cache before the crawl loop."""
 
+    @pytest.mark.asyncio
+    async def test_prefetch_deduplicates_by_scheme_and_authority(self) -> None:
+        """Preload both schemes once when start URLs repeat paths on each origin."""
+        fetch_fn, calls = self._make_counting_fetch()
+        spider = MockSpider(
+            robots_txt_obey=True,
+            start_urls=[
+                "http://example.com/a",
+                "https://example.com/a",
+                "http://example.com/b",
+                "https://example.com/b",
+            ],
+        )
+        engine = _make_engine(spider=spider)
+        engine._robots_manager = RobotsTxtManager(fetch_fn)
+
+        await engine._prefetch_robots_txt()
+
+        assert sorted(calls) == [
+            ("http://example.com/robots.txt", "default"),
+            ("https://example.com/robots.txt", "default"),
+        ]
+
     @staticmethod
     def _make_counting_fetch():
         """Return (fetch_fn, calls_list) where calls_list records every (url, sid) pair."""
@@ -998,3 +1021,34 @@ class TestPrefetchRobotsTxt:
         # set of Request.domain values deduplicates to one task per domain
         assert len(calls) == 1
         assert calls[0][0] == "https://example.com/robots.txt"
+
+
+class TestRobotsTxtDelay:
+    """Robots.txt delays are resolved and cached per origin."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("schemes", [("http", "https"), ("https", "http")])
+    async def test_download_delays_are_cached_separately_by_scheme(
+        self, schemes: tuple[str, str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The engine must not reuse one scheme's resolved delay for the other."""
+        calls: list[str] = []
+        directives = {
+            "http://example.com/page": (2.0, None),
+            "https://example.com/page": (7.0, (1, 9)),
+        }
+
+        async def get_directives(url: str, sid: str) -> tuple[float, tuple[int, int] | None]:
+            """Return different directives for each origin independently of parser caching."""
+            calls.append(url)
+            return directives[url]
+
+        engine = _make_engine(spider=MockSpider(robots_txt_obey=True, download_delay=3.0))
+        monkeypatch.setattr(engine._robots_manager, "get_delay_directives", get_directives)
+
+        for path in ("page", "another-page"):
+            for scheme in schemes:
+                request = Request(f"{scheme}://example.com/{path}", sid="default")
+                assert await engine._get_domain_delay(request) == (3.0 if scheme == "http" else 9.0)
+
+        assert sorted(calls) == sorted(directives)

--- a/tests/spiders/test_robotstxt.py
+++ b/tests/spiders/test_robotstxt.py
@@ -231,6 +231,38 @@ class TestGetDelayDirectives:
 
 class TestCachingBehaviour:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("warm_cache", ["http", "https", "prefetch"])
+    async def test_http_and_https_keep_separate_policies(self, warm_cache: str) -> None:
+        """Each scheme retains its own rules and delays, regardless of fetch order."""
+        calls: list[str] = []
+        policies = {
+            "http://example.com/robots.txt": "User-agent: *\nDisallow: /http-only/\nCrawl-delay: 2\nRequest-rate: 1/4\n",
+            "https://example.com/robots.txt": "User-agent: *\nDisallow: /https-only/\nCrawl-delay: 7\nRequest-rate: 1/9\n",
+        }
+
+        async def fetch(url: str, sid: str) -> MockResponse:
+            """Serve independent policies and allow concurrent prefetches to overlap."""
+            calls.append(url)
+            await asyncio.sleep(0)
+            return MockResponse(body=policies[url].encode())
+
+        mgr = RobotsTxtManager(fetch)
+        if warm_cache == "prefetch":
+            await mgr.prefetch(["http://example.com/", "https://example.com/"], "s1")
+        else:
+            await mgr.can_fetch(f"{warm_cache}://example.com/", "s1")
+
+        for _ in range(2):
+            assert await mgr.can_fetch("http://example.com/http-only/page", "s1") is False
+            assert await mgr.can_fetch("http://example.com/https-only/page", "s1") is True
+            assert await mgr.can_fetch("https://example.com/http-only/page", "s1") is True
+            assert await mgr.can_fetch("https://example.com/https-only/page", "s1") is False
+            assert await mgr.get_delay_directives("http://example.com/page", "s1") == (2.0, (1, 4))
+            assert await mgr.get_delay_directives("https://example.com/page", "s1") == (7.0, (1, 9))
+
+        assert sorted(calls) == sorted(policies)
+
+    @pytest.mark.asyncio
     async def test_second_call_same_domain_uses_cache(self):
         fetch_fn = make_fetch_fn(content=ROBOTS_BASIC)
         mgr = RobotsTxtManager(fetch_fn)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Scrapling!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue in the additional information section.
-->

When `robots_txt_obey=True`, HTTP and HTTPS URLs sharing a hostname reuse the same cached robots.txt parser. For example, after checking an HTTP URL whose policy allows `/private/`, an HTTPS URL can also be allowed even when its own robots.txt disallows that path. Reversing the fetch order can wrongly block allowed pages. The engine also reuses the first scheme's crawl delay and prefetches only one scheme from `start_urls`.

Cache parsers by their robots.txt URL, cache resolved delays by scheme and authority, and prefetch each distinct origin. Requests to different paths on the same origin still share their cached policy and delay. The getting-started guide now explains that HTTP and HTTPS policies are separate.

This follows the scope of robots.txt described in [RFC 9309 section 2.3](https://www.rfc-editor.org/rfc/rfc9309.html#section-2.3), also illustrated explicitly in [Google's protocol/host/port examples](https://developers.google.com/crawling/docs/robots-txt/robots-txt-spec#file-location).

### Reproduction and validation

Six regression cases exercise independent HTTP/HTTPS allow/disallow rules and delay directives, both lookup orders, concurrent prefetching, and duplicate seed paths. The engine delay tests isolate its own cache from the parser cache, so fixing just the parser cannot make them pass. All six reproduced the defect on unmodified `dev`.

On Python 3.13, the full suite passes using the project's separate async, synchronous, and browser groups:

- `pytest tests/ -m asyncio -k 'not (DynamicFetcher or StealthyFetcher)' --cov=scrapling`: 291 passed.
- `pytest tests/ -m 'not asyncio' -k 'not (DynamicFetcher or StealthyFetcher)' -n 4 --cov=scrapling --cov-append`: 675 passed.
- `pytest tests/ -k 'DynamicFetcher or StealthyFetcher' --cov=scrapling --cov-append`: 25 passed.
- Combined coverage: 91%.
- Final focused run after extending the delay regression to different paths: 111 passed.
- `pre-commit run --all-files`, `mypy scrapling/`, and `pyright --pythonpath .venv/bin/python scrapling/`: passed.

### AI assistance disclosure

Investigation, implementation, regression tests, documentation, and this PR description were primarily written with Codex. The change was checked against the existing cache and scheduling paths and validated using the tests above.


### Type of change:
<!--
  What type of change does your PR introduce to Scrapling?
  NOTE: Please, check at least 1 box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->



- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
- [ ] Documentation change?

### Additional information
<!--
  Details are important and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes an issue: fixes # (no existing issue; reproduction included above)
- This PR is related to an issue: # (none)
- Link to documentation pull request: **Included in this PR.**

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/D4Vinci/Scrapling/blob/main/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] All new Python files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Python naming conventions.
* [x] All function parameters and return values are annotated with Python [type hints](https://docs.python.org/3/library/typing.html).
* [x] All functions have doc-strings.
