### PR TITLE
fix(cli): gracefully skip playwright install-deps on non-apt Linux

### DIFF
--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -28,3 +28,6 @@ and the installation of the fetchers' dependencies with the following command
 scrapling install
 ```
 This downloads all browsers, along with their system dependencies and fingerprint manipulation dependencies.
+
+!!! note "Non-Debian Linux distributions (Arch Linux, Fedora, Alpine, etc.)"
+    On Linux systems where `apt-get` is unavailable, `scrapling install` downloads the Chromium browser and completes the setup, but skips automatic system package installation. If Chromium fails to launch, install any missing system libraries using your distribution's package manager.

--- a/scrapling/cli.py
+++ b/scrapling/cli.py
@@ -1,7 +1,8 @@
 from os import environ
 from pathlib import Path
+from shutil import which as shutil_which
 from subprocess import check_output
-from sys import executable as python_executable
+from sys import executable as python_executable, platform as sys_platform
 
 from scrapling import __version__
 from scrapling.core.utils import log
@@ -117,22 +118,28 @@ def __BuildRequest(headers: List[str], cookies: str, params: str, json: Optional
     type=bool,
     help="Force Scrapling to reinstall all Fetchers dependencies",
 )
-def install(force):  # pragma: no cover
+def install(force):
     if force or not __PACKAGE_DIR__.joinpath(".scrapling_dependencies_installed").exists():
         __Execute(
             [python_executable, "-m", "playwright", "install", "chromium"],
             "Playwright browsers",
         )
-        __Execute(
-            [
-                python_executable,
-                "-m",
-                "playwright",
-                "install-deps",
-                "chromium",
-            ],
-            "Playwright dependencies",
-        )
+        if sys_platform.startswith("linux") and not shutil_which("apt-get"):
+            print(
+                "Skipping automatic system dependencies installation: 'apt-get' not found. "
+                "Please install any missing Chromium system dependencies using your distribution's package manager if needed."
+            )
+        else:
+            __Execute(
+                [
+                    python_executable,
+                    "-m",
+                    "playwright",
+                    "install-deps",
+                    "chromium",
+                ],
+                "Playwright dependencies",
+            )
         from tld.utils import update_tld_names
 
         update_tld_names(fail_silently=True)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -5,7 +5,7 @@ import pytest_httpbin
 
 from scrapling.parser import Selector
 from scrapling import __version__
-from scrapling.cli import main, shell, mcp, get, post, put, delete, fetch, stealthy_fetch
+from scrapling.cli import main, shell, mcp, get, post, put, delete, fetch, stealthy_fetch, install, python_executable
 
 
 @pytest_httpbin.use_class_based_httpbin
@@ -336,3 +336,47 @@ class TestCLI:
             call_kwargs = mock_get.call_args[1]
             assert isinstance(call_kwargs["impersonate"], str)
             assert call_kwargs["impersonate"] == "chrome"
+
+    def test_install_skips_apt_dependencies_when_unsupported(self, runner, tmp_path):
+        """On Linux systems without apt-get, install should download browsers but skip install-deps."""
+        marker_file = tmp_path / ".scrapling_dependencies_installed"
+        with (
+            patch("scrapling.cli.__PACKAGE_DIR__", tmp_path),
+            patch("scrapling.cli.sys_platform", "linux"),
+            patch("scrapling.cli.shutil_which", return_value=None),
+            patch("scrapling.cli.__Execute") as mock_execute,
+            patch("tld.utils.update_tld_names") as mock_tld,
+        ):
+            result = runner.invoke(install, ["--force"])
+            assert result.exit_code == 0
+            assert "Skipping automatic system dependencies installation: 'apt-get' not found" in result.output
+            assert mock_execute.call_count == 1
+            assert mock_execute.call_args[0][0] == [python_executable, "-m", "playwright", "install", "chromium"]
+            mock_tld.assert_called_once_with(fail_silently=True)
+            assert marker_file.exists()
+
+    def test_install_runs_apt_dependencies_when_supported(self, runner, tmp_path):
+        """On Linux systems with apt-get (or non-Linux systems), install should run install-deps."""
+        marker_file = tmp_path / ".scrapling_dependencies_installed"
+        with (
+            patch("scrapling.cli.__PACKAGE_DIR__", tmp_path),
+            patch("scrapling.cli.sys_platform", "linux"),
+            patch("scrapling.cli.shutil_which", return_value="/usr/bin/apt-get"),
+            patch("scrapling.cli.__Execute") as mock_execute,
+            patch("tld.utils.update_tld_names") as mock_tld,
+        ):
+            result = runner.invoke(install, ["--force"])
+            assert result.exit_code == 0
+            assert mock_execute.call_count == 2
+            mock_tld.assert_called_once_with(fail_silently=True)
+            assert marker_file.exists()
+
+    def test_install_already_installed(self, runner, tmp_path):
+        """When dependencies are already installed and --force is not passed, install should be a no-op."""
+        marker_file = tmp_path / ".scrapling_dependencies_installed"
+        marker_file.touch()
+        with patch("scrapling.cli.__PACKAGE_DIR__", tmp_path), patch("scrapling.cli.__Execute") as mock_execute:
+            result = runner.invoke(install)
+            assert result.exit_code == 0
+            assert "The dependencies are already installed" in result.output
+            mock_execute.assert_not_called()


### PR DESCRIPTION
Resolves #439.

### Problem
On Linux distributions that do not use `apt-get` (such as Arch Linux, Manjaro, Fedora, Alpine, Void, NixOS, etc.), running `scrapling install` crashes with:
```text
Error: Failed to run 'apt-get install -s' to simulate dependency install: spawn apt-get ENOENT
subprocess.CalledProcessError: Command '['.../python', '-m', 'playwright', 'install-deps', 'chromium']' returned non-zero exit status 1.
```
This halts installation prematurely, preventing TLD updates and leaving `.scrapling_dependencies_installed` uncreated.

### Solution
1. In `scrapling.cli.install`: Check if running on Linux and whether `shutil.which("apt-get")` is available before invoking `playwright install-deps chromium`.
2. When `apt-get` is absent on Linux, print a message informing the user that system dependencies can be installed using their distribution package manager if Chromium needs them, and continue with the setup.
3. Added CLI unit tests covering:
   - Linux without `apt-get` (skips `install-deps`, prints guidance, completes setup)
   - Linux with `apt-get` / supported systems (executes `install-deps`)
   - Re-running `install` when already installed
4. Added documentation note in `docs/cli/overview.md`.
